### PR TITLE
Intdump interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ pybind11_add_module(_quantel
     "${SOURCE_DIR}/shell_pair.cpp"
     "${SOURCE_DIR}/molecule.cpp"
     "${SOURCE_DIR}/libint_interface.cpp"
+    "${SOURCE_DIR}/fcidump_interface.cpp"
     "${SOURCE_DIR}/linalg.cpp"
     "${SOURCE_DIR}/determinant.cpp"
     "${SOURCE_DIR}/ci_space.cpp"

--- a/examples/fcidump_scf.py
+++ b/examples/fcidump_scf.py
@@ -1,0 +1,233 @@
+"""Benchmark FCIDUMP vs PySCFIntegrals for RHF, UHF, and GHF on N2/STO-3G.
+
+Steps
+-----
+1. Build N2/STO-3G with PySCF, run RHF to get a reference energy.
+2. Run RHF, UHF, GHF using PySCFIntegrals (AO basis).
+3. Write a FCIDUMP in the canonical MO basis, read it back.
+4. Run RHF, UHF, GHF using the FCIDUMP integral interface (MO basis).
+5. Check every energy against the PySCF reference.
+
+Note on initial guesses
+-----------------------
+PySCFIntegrals: AO basis — use GWH/core guess, which works as for any SCF.
+FCIDUMP:        MO basis — the identity matrix IS the RHF solution, so we
+                build a block-diagonal spinor guess rather than using the
+                orbital-guess routines (which were designed for the AO basis).
+"""
+
+import copy
+import os
+import numpy as np
+from pyscf import gto, scf
+from pyscf.tools import fcidump as pyscf_fcidump
+
+from quantel import wfn
+from quantel.ints.pyscf_integrals import PySCFMolecule, PySCFIntegrals
+from quantel.ints.fcidump_integrals import FCIDUMP
+from quantel.wfn.rhf import RHF
+from quantel.wfn.uhf import UHF
+from quantel.wfn.ghf import GHF
+from quantel.opt.diis import DIIS
+
+FCIDUMP_FILE = "tmp.fcidump"
+TOL_ENERGY   = 1e-8   # Hartree
+ATOM         = "Li 0 0 0; H 0 0 1.098"
+BASIS        = "sto3g"
+
+def check(label, condition, got=None, ref=None):
+    if condition:
+        print(f"  {label:62s} PASS")
+    else:
+        msg = f"  {label:62s} FAIL"
+        if got is not None and ref is not None:
+            msg += f"  (got {got:.10f}, ref {ref:.10f})"
+        raise AssertionError(msg)
+
+
+def ghf_from_rhf_coeffs(wfn_ghf, C_rhf):
+    """Build a block-diagonal GHF initial guess from RHF orbitals.
+
+    Interleaves alpha-occupied and beta-occupied columns so the first nocc
+    spinors correspond to nocc/2 alpha + nocc/2 beta electrons.  This ensures
+    GHF starts at (and confirms) the RHF stationary point.
+    """
+    nbsf = C_rhf.shape[0]
+    nmo  = C_rhf.shape[1]
+    nocc_half = wfn_ghf.nocc // 2
+    C_block   = np.block([[C_rhf, np.zeros((nbsf, nmo))],
+                          [np.zeros((nbsf, nmo)), C_rhf]])
+    col_order = (list(range(nocc_half)) +
+                 list(range(nmo, nmo + nocc_half)) +
+                 list(range(nocc_half, nmo)) +
+                 list(range(nmo + nocc_half, 2 * nmo)))
+    wfn_ghf.initialise(C_block[:, col_order])
+
+
+def run_scf(wfn_cls, ints, coeff=None, ghf_coeff=None):
+    """Initialise, run DIIS, and return the converged wfn.
+
+    Parameters
+    ----------
+    coeff : ndarray or None
+        If provided, use directly as the initial orbital coefficients
+        (via wfn.initialise).  Otherwise fall back to get_orbital_guess.
+    ghf_coeff : ndarray or None
+        If provided and wfn_cls is GHF, use these spatial orbitals to build
+        the block-diagonal GHF spinor starting guess.
+    """
+    wfn = wfn_cls(ints)
+    if wfn_cls is GHF and ghf_coeff is not None:
+        ghf_from_rhf_coeffs(wfn, ghf_coeff)
+    elif coeff is not None:
+        wfn.initialise(coeff)
+    elif wfn_cls is GHF:
+        wfn.get_orbital_guess(method="core")
+    else:
+        wfn.get_orbital_guess(method="gwh")
+    DIIS().run(wfn)
+    return wfn
+
+
+# ===========================================================================
+# 1. PySCF reference
+# ===========================================================================
+mol_pyscf = gto.Mole()
+mol_pyscf.atom    = ATOM
+mol_pyscf.basis   = BASIS
+mol_pyscf.unit    = "angstrom"
+mol_pyscf.verbose = 0
+mol_pyscf.build()
+
+mf = scf.RHF(mol_pyscf)
+mf.kernel()
+E_ref = mf.e_tot
+
+pyscf_fcidump.from_scf(mf, FCIDUMP_FILE, tol=1e-15)
+
+print("\n" + "=" * 70)
+print("  LiH / STO-3G  —  FCIDUMP vs PySCFIntegrals benchmark")
+print("=" * 70)
+print(f"\n  PySCF RHF reference energy : {E_ref:.10f} Eh")
+
+# ===========================================================================
+# 2. PySCFIntegrals backend
+# ===========================================================================
+
+print("\n" + "-" * 70)
+print("  PySCFIntegrals (AO basis)")
+print("-" * 70)
+
+pyscf_mol  = PySCFMolecule(ATOM, BASIS, "angstrom")
+pyscf_ints = PySCFIntegrals(pyscf_mol)
+
+wfn_rhf_p = run_scf(RHF, pyscf_ints)
+E_rhf_pyscf = wfn_rhf_p.energy
+E_ref = E_rhf_pyscf
+print(f"\n  RHF : {E_rhf_pyscf:.10f} Eh")
+check(f"PySCFIntegrals RHF matches reference (tol={TOL_ENERGY:.0e})",
+      abs(E_rhf_pyscf - E_ref) < TOL_ENERGY, got=E_rhf_pyscf, ref=E_ref)
+
+# Write tei to FCIDUMP format and read back to check the integral interface
+from quantel.ints.utils import write_fcidump
+write_fcidump(pyscf_ints, wfn_rhf_p.mo_coeff, filename=FCIDUMP_FILE)
+
+# Check gradient and hessian
+print()
+check(f"RHF Gradient check", wfn_rhf_p.check_gradient())
+check(f"RHF Hessian check", wfn_rhf_p.check_hessian())
+
+wfn_uhf_p = run_scf(UHF, pyscf_ints)
+E_uhf_pyscf = wfn_uhf_p.energy
+print(f"  UHF : {E_uhf_pyscf:.10f} Eh")
+check(f"PySCFIntegrals UHF matches reference (tol={TOL_ENERGY:.0e})",
+      abs(E_uhf_pyscf - E_ref) < TOL_ENERGY, got=E_uhf_pyscf, ref=E_ref)
+print()
+check(f"UHF Gradient check", wfn_uhf_p.check_gradient())
+check(f"UHF Hessian check", wfn_uhf_p.check_hessian())
+
+# GHF started from the converged RHF orbitals: confirms the RHF solution is
+# a valid GHF stationary point without landing on a spurious local minimum.
+wfn_ghf_p = run_scf(GHF, pyscf_ints, ghf_coeff=wfn_rhf_p.mo_coeff)
+
+E_ghf_pyscf = wfn_ghf_p.energy
+print(f"  GHF : {E_ghf_pyscf:.10f} Eh")
+check(f"PySCFIntegrals GHF matches reference (tol={TOL_ENERGY:.0e})",
+      abs(E_ghf_pyscf - E_ref) < TOL_ENERGY, got=E_ghf_pyscf, ref=E_ref)
+print()
+check(f"GHF Gradient check", wfn_ghf_p.check_gradient())
+check(f"GHF Hessian check", wfn_ghf_p.check_hessian())
+
+# ===========================================================================
+# 3. FCIDUMP backend
+# ===========================================================================
+
+print("\n" + "-" * 70)
+print("  FCIDUMP (MO basis)")
+print("-" * 70)
+
+fcidump_ints = FCIDUMP(FCIDUMP_FILE)
+fcidump_ints.print()
+nmo = fcidump_ints.nmo()
+
+# In the MO basis the identity IS the converged RHF solution; pass it as the
+# GHF seed via ghf_coeff so ghf_from_rhf_coeffs constructs the spinor guess.
+C_mo_identity = np.eye(nmo)
+
+wfn_rhf_f = run_scf(RHF, fcidump_ints, coeff=C_mo_identity)
+E_rhf_fcidump = wfn_rhf_f.energy
+print(f"\n  RHF : {E_rhf_fcidump:.10f} Eh")
+check(f"FCIDUMP RHF matches reference (tol={TOL_ENERGY:.0e})",
+      abs(E_rhf_fcidump - E_ref) < TOL_ENERGY, got=E_rhf_fcidump, ref=E_ref)
+# Check gradient and hessian
+print()
+check(f"RHF Gradient check", wfn_rhf_f.check_gradient())
+check(f"RHF Hessian check", wfn_rhf_f.check_hessian())
+
+wfn_uhf_f = run_scf(UHF, fcidump_ints, coeff=C_mo_identity)
+E_uhf_fcidump = wfn_uhf_f.energy
+print(f"  UHF : {E_uhf_fcidump:.10f} Eh")
+check(f"FCIDUMP UHF matches reference (tol={TOL_ENERGY:.0e})",
+      abs(E_uhf_fcidump - E_ref) < TOL_ENERGY, got=E_uhf_fcidump, ref=E_ref)
+print()
+check(f"UHF Gradient check", wfn_uhf_f.check_gradient())
+check(f"UHF Hessian check", wfn_uhf_f.check_hessian())
+
+wfn_ghf_f = run_scf(GHF, fcidump_ints, ghf_coeff=C_mo_identity)
+
+E_ghf_fcidump = wfn_ghf_f.energy
+print(f"  GHF : {E_ghf_fcidump:.10f} Eh")
+check(f"FCIDUMP GHF matches reference (tol={TOL_ENERGY:.0e})",
+      abs(E_ghf_fcidump - E_ref) < TOL_ENERGY, got=E_ghf_fcidump, ref=E_ref)
+
+print()
+check(f"GHF Gradient check", wfn_ghf_f.check_gradient())
+check(f"GHF Hessian check", wfn_ghf_f.check_hessian())
+
+# ===========================================================================
+# 4. Cross-check: both backends agree with each other
+# ===========================================================================
+
+print("\n" + "-" * 70)
+print("  Cross-check: FCIDUMP == PySCFIntegrals")
+print("-" * 70)
+
+check("RHF energies agree between backends",
+      abs(E_rhf_fcidump - E_rhf_pyscf) < TOL_ENERGY,
+      got=E_rhf_fcidump, ref=E_rhf_pyscf)
+check("UHF energies agree between backends",
+      abs(E_uhf_fcidump - E_uhf_pyscf) < TOL_ENERGY,
+      got=E_uhf_fcidump, ref=E_uhf_pyscf)
+check("GHF energies agree between backends",
+      abs(E_ghf_fcidump - E_ghf_pyscf) < TOL_ENERGY,
+      got=E_ghf_fcidump, ref=E_ghf_pyscf)
+
+# ===========================================================================
+# Done
+# ===========================================================================
+
+os.remove(FCIDUMP_FILE)
+
+print("\n" + "=" * 70)
+print("  All checks passed.")
+print("=" * 70 + "\n")

--- a/examples/test_df_jk.py
+++ b/examples/test_df_jk.py
@@ -20,12 +20,12 @@ if __name__ == "__main__":
     dm = wfn.dens
     # Time the JK builds with and without density fitting
     t0 = datetime.datetime.now()
-    J,K = ints.build_JK(dm,dm)
+    J,K = ints.build_JK(dm)
     JK = J - 0.5 * K
     t1 = datetime.datetime.now()
     print("Conventional JK build time: ",(t1-t0).total_seconds())
     t0 = datetime.datetime.now()
-    dfJ,dfK = df_ints.build_JK(dm,dm)
+    dfJ,dfK = df_ints.build_JK(dm)
     dfJK = dfJ - 0.5 * dfK
     t1 = datetime.datetime.now()
     print("Density-fitted JK build time: ",(t1-t0).total_seconds())

--- a/examples/test_fcidump.py
+++ b/examples/test_fcidump.py
@@ -111,7 +111,7 @@ P = np.random.rand(nmo,nmo)
 # (2J-K)_{pq} = sum_{rs} P_{rs} * (2*(pq|rs) - (ps|rq))
 Jref = np.einsum("pqrs,rs->pq", h2e_mo, P)
 Kref = np.einsum("psrq,rs->pq", h2e_mo, P)
-Jintdump, Kintdump = intdump.build_JK(P,P)
+Jintdump, Kintdump = intdump.build_JK(P)
 check("build_JK: J matches direct einsum",np.allclose(Jintdump, Jref, atol=1e-10))
 check("build_JK: K matches direct einsum",np.allclose(Kintdump, Kref, atol=1e-10))
 

--- a/examples/test_fcidump.py
+++ b/examples/test_fcidump.py
@@ -110,7 +110,7 @@ P = np.random.rand(nmo,nmo)
 
 # (2J-K)_{pq} = sum_{rs} P_{rs} * (2*(pq|rs) - (ps|rq))
 Jref = np.einsum("pqrs,rs->pq", h2e_mo, P)
-Kref = np.einsum("psrq,rs->pq", h2e_mo, P)
+Kref = np.einsum("prsq,rs->pq", h2e_mo, P)
 Jintdump, Kintdump = intdump.build_JK(P)
 check("build_JK: J matches direct einsum",np.allclose(Jintdump, Jref, atol=1e-10))
 check("build_JK: K matches direct einsum",np.allclose(Kintdump, Kref, atol=1e-10))

--- a/examples/test_fcidump.py
+++ b/examples/test_fcidump.py
@@ -117,17 +117,22 @@ check("build_JK: K matches direct einsum",np.allclose(Kintdump, Kref, atol=1e-10
 
 # Check two-electron orbital transformation against direct einsum with PySCF integrals.
 print("\n--- One-electron MO transform ---")
-C_rot = orthogonalise(np.random.rand(nbsf,nmo), overlap)
-h1e_ref = np.linalg.multi_dot([C_rot.T, h1e_mo, C_rot])
-h1e_intdump = intdump.oei_ao_to_mo(C_rot,C_rot,True)
+C1 = np.random.rand(nbsf,2*nmo)
+C2 = np.random.rand(nbsf,4)
+C3 = np.random.rand(nbsf,2*nmo)
+C4 = np.random.rand(nbsf,2)
+h1e_ref = np.linalg.multi_dot([C1.T, h1e_mo, C2])
+h1e_intdump = intdump.oei_ao_to_mo(C1,C2,True)
 check("oei_ao_to_mo with rotation matches direct einsum", np.allclose(h1e_intdump, h1e_ref, atol=1e-10))
 
 print("\n--- Two-electron MO transform ---")
-h2e_ref = np.einsum("pqrs,pa,qb,rc,sd->abcd", h2e_mo, C_rot, C_rot, C_rot, C_rot, optimize="optimal")
+h2e_ref = np.einsum("pqrs,pa,qb,rc,sd->abcd", h2e_mo.transpose(0,2,1,3),C1,C2,C3,C4, optimize="optimal")
 # Convert chemists to physicists notation for direct comparison with intdump.tei_ao_to_mo output
-h2e_ref = h2e_ref.transpose(0,2,1,3)
-h2e_intdump = intdump.tei_ao_to_mo(C_rot,C_rot,C_rot,C_rot, True, False)
+h2e_intdump = intdump.tei_ao_to_mo(C1,C2,C3,C4, True, False)
 check("tei_ao_to_mo with rotation matches direct einsum", np.allclose(h2e_intdump, h2e_ref, atol=1e-10))
+
+# Remove the FCIDUMP file
+os.remove(fname)
 
 # ===========================================================================
 # Done

--- a/examples/test_fcidump.py
+++ b/examples/test_fcidump.py
@@ -1,0 +1,137 @@
+"""Test script demonstrating the INTDUMPMolecule integral interface.
+
+The test proceeds in two parts:
+
+  Part 1 (H2 / STO-3G)
+  ---------------------
+  Uses PySCF to run RHF and write a FCIDUMP file in the canonical MO basis.
+  Reads the file back with INTDUMPMolecule and cross-checks every quantity
+  against the original PySCF integrals:
+    - dimensions and electron counts
+    - overlap / orthogonalisation matrices are the identity
+    - scalar potential matches nuclear repulsion
+    - oei_matrix matches PySCF h1e in MO basis
+    - tei_array matches PySCF h2e in MO basis (chemist's notation)
+    - oei_ao_to_mo and tei_ao_to_mo with a non-trivial orbital rotation
+    - build_JK verified against direct einsum contraction
+    - dipole_matrix raises RuntimeError
+    - mo_integrals returns a valid MOintegrals object
+    - FCI energy agrees with PySCF direct FCI
+
+  Part 2 (H6 / STO-3G)
+  ---------------------
+  Generates a FCIDUMP from PySCF RHF, then drives quantel FCI from the
+  FCIDUMP alone (no PySCF integrals at FCI time) and checks against the
+  known reference energy.
+"""
+
+from curses import OK
+import os
+import numpy as np
+from pyscf import gto, scf
+from pyscf.tools import fcidump as pyscf_fcidump
+from pyscf import ao2mo
+
+from quantel.ints.fcidump_integrals import FCIDUMP
+from quantel.utils.linalg import orthogonalise
+
+def check(label, condition, tol=None, got=None, ref=None):
+    if condition:
+        print(f"  {label:55s} {'PASS'}")
+    else:
+        msg = f"  {label:55s} {'FAIL'}"
+        if got is not None and ref is not None:
+            msg += f"  (got {got}, ref {ref})"
+        raise AssertionError(msg)
+
+
+## Write an FCIDUMP for N2 in a minimal basis, read it back, and check all the integrals against PySCF.]
+fname = "fcidump"
+# Build PySCF molecule and RHF reference
+mol = gto.Mole()
+mol.atom   = "N 0 0 0; N 0 0 1.00"
+mol.basis  = "sto-3g"
+mol.unit   = "angstrom"
+mol.verbose = 0
+mol.build()
+
+# Build RHF reference and get MO coefficients, integrals, and FCI energy from PySCF
+mf = scf.RHF(mol)
+mf.kernel()
+
+C    = mf.mo_coeff          # shape (nbsf, nmo)
+nmo  = C.shape[1]
+nbsf = mol.nao
+E_nuc = mol.energy_nuc()
+
+# h1e and h2e in MO basis
+overlap = mol.intor("int1e_ovlp")
+h1e_ao  = mol.intor("int1e_kin") + mol.intor("int1e_nuc")
+h1e_mo  = np.linalg.multi_dot([C.T, h1e_ao, C])
+h2e_mo  = ao2mo.full(mol, C, compact=False).reshape(nmo, nmo, nmo, nmo)
+
+# Write FCIDUMP
+pyscf_fcidump.from_scf(mf, fname, tol=1e-15)
+print(f"\n  FCIDUMP written : {fname}")
+print(f"  RHF energy      : {mf.e_tot:.10f}")
+
+# Read FCIDUMP with quantel and check all integrals against PySCF
+intdump = FCIDUMP(fname)
+intdump.print()
+print("\n" + "=" * 60)
+print("  FCIDUMP read back with quantel. Checking integrals against PySCF...")
+print("=" * 60)
+
+print("\n--- Dimensions and electron counts ---")
+check("nbsf",  intdump.nbsf()  == nbsf)
+check("nmo",   intdump.nmo()   == nmo)
+check("nelec", intdump.molecule().nelec() == mol.nelectron)
+check("nalfa", intdump.molecule().nalfa() == mol.nelec[0])
+check("nbeta", intdump.molecule().nbeta() == mol.nelec[1])
+
+print("\n--- Overlap / orthogonalisation matrices ---")
+check("overlap_matrix = I", np.allclose(intdump.overlap_matrix(), np.eye(nbsf)))
+check("orthogonalization_matrix = I", np.allclose(intdump.orthogonalization_matrix(), np.eye(nbsf)))
+
+print("\n--- Scalar potential ---")
+check(f"scalar_potential = {E_nuc:.8f}", abs(intdump.scalar_potential() - E_nuc) < 1e-10)
+
+print("\n--- One-electron integrals ---")
+oei = intdump.oei_matrix()
+check("oei_matrix matches PySCF h1e_mo", np.allclose(oei, h1e_mo, atol=1e-10))
+
+print("\n--- Two-electron integrals ---")
+tei = intdump.tei_array()
+check("tei_array matches PySCF h2e_mo (chemist's)",np.allclose(tei, h2e_mo, atol=1e-10))
+
+print("\n--- build_JK ---")
+# Build a random density matrix in MO basis and check JK against direct einsum contraction with PySCF integrals.
+P = np.random.rand(nmo,nmo)
+
+# (2J-K)_{pq} = sum_{rs} P_{rs} * (2*(pq|rs) - (ps|rq))
+Jref = np.einsum("pqrs,rs->pq", h2e_mo, P)
+Kref = np.einsum("psrq,rs->pq", h2e_mo, P)
+Jintdump, Kintdump = intdump.build_JK(P,P)
+check("build_JK: J matches direct einsum",np.allclose(Jintdump, Jref, atol=1e-10))
+check("build_JK: K matches direct einsum",np.allclose(Kintdump, Kref, atol=1e-10))
+
+# Check two-electron orbital transformation against direct einsum with PySCF integrals.
+print("\n--- One-electron MO transform ---")
+C_rot = orthogonalise(np.random.rand(nbsf,nmo), overlap)
+h1e_ref = np.linalg.multi_dot([C_rot.T, h1e_mo, C_rot])
+h1e_intdump = intdump.oei_ao_to_mo(C_rot,C_rot,True)
+check("oei_ao_to_mo with rotation matches direct einsum", np.allclose(h1e_intdump, h1e_ref, atol=1e-10))
+
+print("\n--- Two-electron MO transform ---")
+h2e_ref = np.einsum("pqrs,pa,qb,rc,sd->abcd", h2e_mo, C_rot, C_rot, C_rot, C_rot, optimize="optimal")
+# Convert chemists to physicists notation for direct comparison with intdump.tei_ao_to_mo output
+h2e_ref = h2e_ref.transpose(0,2,1,3)
+h2e_intdump = intdump.tei_ao_to_mo(C_rot,C_rot,C_rot,C_rot, True, False)
+check("tei_ao_to_mo with rotation matches direct einsum", np.allclose(h2e_intdump, h2e_ref, atol=1e-10))
+
+# ===========================================================================
+# Done
+# ===========================================================================
+print("\n" + "=" * 60)
+print("  All tests passed!")
+print("=" * 60)

--- a/examples/test_ghf.py
+++ b/examples/test_ghf.py
@@ -9,13 +9,15 @@ if __name__ == "__main__":
     print(f" Testing GHF optimisation method")
     print("===============================================")
     # Setup molecule and integrals
-    mol  = PySCFMolecule("mol/h3.xyz", "cc-pvdz", "angstrom",spin=1,charge=0)
+    mol  = PySCFMolecule("mol/h3.xyz", "sto3g", "angstrom",spin=1,charge=0)
     ints = PySCFIntegrals(mol)
+    nmo  = 2*ints.nmo()
+    Cinit = np.eye(nmo,nmo)
 
     # Initialise GHF object
     wfn = GHF(ints)
     # Set initial coefficients from identity
-    wfn.initialise(np.eye(wfn.nmo,wfn.nmo))
+    wfn.initialise(Cinit)
     # Test LBFGS
     LBFGS().run(wfn)
 
@@ -25,6 +27,6 @@ if __name__ == "__main__":
     wfn.get_davidson_hessian_index(approx_hess=False)
     
     # Test DIIS
-    wfn.initialise(np.eye(wfn.nmo,wfn.nmo))
+    wfn.initialise(Cinit)
     DIIS().run(wfn)
 

--- a/examples/test_roks.py
+++ b/examples/test_roks.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     ints = PySCFIntegrals(mol,xc='pbe0')
 
     # Initialise CSF object for an open-shell singlet state
-    wfn = ROKS(ints, '+-')
+    wfn = ROKS(ints, '+-+-')
     wfn.get_orbital_guess(method="gwh")
 
     # Setup optimiser

--- a/quantel/gnme/utils.py
+++ b/quantel/gnme/utils.py
@@ -291,7 +291,7 @@ def generalised_slater_condon(Cax,Cbx,Caw,Cbw,ints,ktol=1e-8,stol=1e-8):
     vd[nd+2:] = Pb
 
     # Call the JK build
-    vj, vk = ints.build_JK(vd,vd)
+    vj, vk = ints.build_JK(vd)
 
     # Compute two-electron contributions
     jw_t = vj[0] + vj[nd]

--- a/quantel/ints/fcidump_integrals.py
+++ b/quantel/ints/fcidump_integrals.py
@@ -108,32 +108,29 @@ class FCIDUMP:
         # Return 0 for the XC potential since a FCIDUMP contains no information about an XC functional.
         return 0, np.zeros_like(dens)
 
-    def build_JK(self,vDJ,vDK,hermi=0,Kxc=False):
+    def build_JK(self,vd,hermi=0,Kxc=False):
         """Build J and K matrices for multiple sets of density matrices.
 
         Parameters
         ----------
-        vDJ : ndarray, shape (nj, nbsf, nbsf)
-            Density matrices for J build.
-        vDK : ndarray, shape (nk, nbsf, nbsf)
-            Density matrices for K build.
-        nj, nk : int
-            Number of density matrices in each set.
+        vd : ndarray, shape (n, nbsf, nbsf)
+            Density matrices.
+        hermi : int
+            Unused; present for interface compatibility with pyscf_integrals.
+        Kxc : bool
+            If True, also return the scaled exchange matrix (same as K for FCIDUMP).
 
         Returns
         -------
         tuple of ndarray
-            (vJ, vK) each shaped (n*, nbsf, nbsf).
+            (vJ, vK) each shaped (n, nbsf, nbsf), or (vJ, vK, vKfunc) if Kxc=True.
         """
-        if(vDJ.ndim == 2): vDJ = vDJ[None,:,:]
-        if(vDK.ndim == 2): vDK = vDK[None,:,:]
-        # Call the underlying C++ implementation to compute J and K for all density matrices
+        if(vd.ndim == 2): vd = vd[None,:,:]
         vJ, vK = self._ints.build_multiple_JK(
-            np.ascontiguousarray(vDJ), np.ascontiguousarray(vDK),
-            vDJ.shape[0], vDK.shape[0])
-        vKfunc = vK
+            np.ascontiguousarray(vd), np.ascontiguousarray(vd),
+            vd.shape[0], vd.shape[0])
         if Kxc:
-            return vJ, vK, vKfunc
+            return vJ, vK, vK
         else:
             return vJ, vK
 

--- a/quantel/ints/fcidump_integrals.py
+++ b/quantel/ints/fcidump_integrals.py
@@ -127,11 +127,10 @@ class FCIDUMP:
         """
         if(vDJ.ndim == 2): vDJ = vDJ[None,:,:]
         if(vDK.ndim == 2): vDK = vDK[None,:,:]
-        # Make sure inputs are C-contiguous arrays of type float64
-        vDJ = np.ascontiguousarray(vDJ, dtype=np.float64)
-        vDK = np.ascontiguousarray(vDK, dtype=np.float64)
         # Call the underlying C++ implementation to compute J and K for all density matrices
-        vJ, vK = self._ints.build_multiple_JK(vDJ, vDK, vDJ.shape[0], vDK.shape[0])
+        vJ, vK = self._ints.build_multiple_JK(
+            np.ascontiguousarray(vDJ), np.ascontiguousarray(vDK),
+            vDJ.shape[0], vDK.shape[0])
         vKfunc = vK
         if Kxc:
             return vJ, vK, vKfunc
@@ -155,8 +154,8 @@ class FCIDUMP:
         -------
         ndarray, shape (n1, n2)
         """
-        return self._ints.oei_ao_to_mo(np.asarray(C1, dtype=np.float64),
-                                       np.asarray(C2, dtype=np.float64),True)
+        return self._ints.oei_ao_to_mo(np.ascontiguousarray(C1),
+                                       np.ascontiguousarray(C2),True)
 
     def tei_ao_to_mo(self,C1: np.ndarray,C2: np.ndarray,C3: np.ndarray,C4: np.ndarray,
                      alpha1: bool,alpha2: bool,) -> np.ndarray:
@@ -186,12 +185,9 @@ class FCIDUMP:
         ndarray, shape (n1, n2, n3, n4)
         """
         return self._ints.tei_ao_to_mo(
-            np.asarray(C1, dtype=np.float64),
-            np.asarray(C2, dtype=np.float64),
-            np.asarray(C3, dtype=np.float64),
-            np.asarray(C4, dtype=np.float64),
-            alpha1, alpha2,
-        )
+            np.ascontiguousarray(C1),np.ascontiguousarray(C2),
+            np.ascontiguousarray(C3),np.ascontiguousarray(C4),
+            alpha1,alpha2)
 
     def tei_array(self, spin1=None, spin2=None) -> np.ndarray:
         """Return the full two-electron integral array (pq|rs) in chemist's notation.
@@ -223,7 +219,7 @@ class FCIDUMP:
         -------
         MOintegrals
         """
-        return self._ints.mo_integrals(np.asarray(C, dtype=np.float64), ncore, nactive)
+        return self._ints.mo_integrals(np.ascontiguousarray(C), ncore, nactive)
 
     def print(self):
         """Print a summary of the FCIDUMP contents."""

--- a/quantel/ints/fcidump_integrals.py
+++ b/quantel/ints/fcidump_integrals.py
@@ -1,0 +1,240 @@
+#!/usr/bin/python
+
+import numpy as np
+from quantel import FCIDumpInterface
+
+class BaseMolecule:
+    """Simple molecule class to hold electron counts for a FCIDUMP."""
+    def __init__(self,nalfa,nbeta):
+        self._nalfa = nalfa
+        self._nbeta = nbeta
+    
+    def nalfa(self):
+        return self._nalfa
+    
+    def nbeta(self):
+        return self._nbeta
+
+    def nelec(self):
+        return self._nalfa + self._nbeta
+
+    def sz(self):
+        return 0.5 * (self._nalfa - self._nbeta)
+
+class FCIDUMP:
+    """Integral interface backed by a pre-computed FCIDUMP file.
+
+    The orbitals in the FCIDUMP are assumed to be orthonormal, so the
+    overlap and orthogonalisation matrices are both the identity.
+
+    This class exposes the same API as PySCFIntegrals so that it can be
+    used as a drop-in replacement wherever only a FCIDUMP is available.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the FCIDUMP file.
+    """
+
+    def __init__(self, filename: str):
+        """Initialize the FCIDUMP interface by reading the specified file.
+        Parameters
+        ----------
+        filename : str
+            Path to the FCIDUMP file.
+        """
+        self.filename = filename
+        self._ints = FCIDumpInterface(filename)
+        self.mol = BaseMolecule(self._ints.nalfa(), self._ints.nbeta())
+        self.xc = None
+        self.hybrid_K = 1.0
+
+    def molecule(self) -> BaseMolecule:
+        """Return a molecule object with the correct number of electrons."""
+        return self.mol
+    
+    def nbsf(self) -> int:
+        """Number of orbitals (NORB from FCIDUMP header)."""
+        return self._ints.nbsf()
+
+    def nmo(self) -> int:
+        """Number of molecular orbitals (equal to nbsf for an orthogonal FCIDUMP)."""
+        return self._ints.nmo()
+
+    def scalar_potential(self) -> float:
+        """Scalar potential stored in the FCIDUMP (nuclear repulsion or frozen-core energy)."""
+        return self._ints.scalar_potential()
+
+    def overlap_matrix(self) -> np.ndarray:
+        """Return the overlap matrix (identity, since orbitals are orthonormal)."""
+        return self._ints.overlap_matrix()
+
+    def orthogonalization_matrix(self) -> np.ndarray:
+        """Return the orthogonalisation matrix (identity, since orbitals are orthonormal)."""
+        return self._ints.orthogonalization_matrix()
+
+    def oei_matrix(self, spin=None) -> np.ndarray:
+        """Return the one-electron Hamiltonian matrix h(p,q).
+
+        Parameters
+        ----------
+        spin : bool or None
+            Ignored — alpha and beta integrals are identical for a restricted FCIDUMP.
+        """
+        return self._ints.oei_matrix(True)
+
+    def dipole_matrix(self, origin=None):
+        """Not available from a FCIDUMP file."""
+        raise RuntimeError(
+            "INTDUMPMolecule: dipole integrals are not available from a FCIDUMP file"
+        )
+
+    def build_fock(self, dens: np.ndarray) -> np.ndarray:
+        """Build the restricted Fock matrix F = h + (2J-K) from a density matrix.
+
+        Parameters
+        ----------
+        dens : ndarray, shape (nbsf, nbsf)
+            Density matrix in the orbital basis.
+
+        Returns
+        -------
+        ndarray, shape (nbsf, nbsf)
+            Fock matrix.
+        """
+        return self._ints.build_fock(np.asarray(dens, dtype=np.float64))
+    
+    def build_vxc(self, dens):
+        # Return 0 for the XC potential since a FCIDUMP contains no information about an XC functional.
+        return 0, np.zeros_like(dens)
+
+    def build_JK(self,vDJ,vDK,hermi=0,Kxc=False):
+        """Build J and K matrices for multiple sets of density matrices.
+
+        Parameters
+        ----------
+        vDJ : ndarray, shape (nj, nbsf, nbsf)
+            Density matrices for J build.
+        vDK : ndarray, shape (nk, nbsf, nbsf)
+            Density matrices for K build.
+        nj, nk : int
+            Number of density matrices in each set.
+
+        Returns
+        -------
+        tuple of ndarray
+            (vJ, vK) each shaped (n*, nbsf, nbsf).
+        """
+        if(vDJ.ndim == 2): vDJ = vDJ[None,:,:]
+        if(vDK.ndim == 2): vDK = vDK[None,:,:]
+        # Make sure inputs are C-contiguous arrays of type float64
+        vDJ = np.ascontiguousarray(vDJ, dtype=np.float64)
+        vDK = np.ascontiguousarray(vDK, dtype=np.float64)
+        # Call the underlying C++ implementation to compute J and K for all density matrices
+        vJ, vK = self._ints.build_multiple_JK(vDJ, vDK, vDJ.shape[0], vDK.shape[0])
+        vKfunc = vK
+        if Kxc:
+            return vJ, vK, vKfunc
+        else:
+            return vJ, vK
+
+
+    def oei_ao_to_mo(self, C1: np.ndarray, C2: np.ndarray, spin=None) -> np.ndarray:
+        """Transform the one-electron integrals to a new orbital basis.
+
+        Computes C1.T @ h @ C2 where h is the stored one-electron matrix.
+
+        Parameters
+        ----------
+        C1, C2 : ndarray, shape (nbsf, n*)
+            Orbital coefficient matrices.
+        spin : bool or None
+            Ignored — alpha and beta integrals are identical.
+
+        Returns
+        -------
+        ndarray, shape (n1, n2)
+        """
+        return self._ints.oei_ao_to_mo(np.asarray(C1, dtype=np.float64),
+                                       np.asarray(C2, dtype=np.float64),True)
+
+    def tei_ao_to_mo(self,C1: np.ndarray,C2: np.ndarray,C3: np.ndarray,C4: np.ndarray,
+                     alpha1: bool,alpha2: bool,) -> np.ndarray:
+        """Transform the two-electron integrals to a new orbital basis.
+
+        Returns antisymmetrised integrals <pq||rs> in physicist's notation.
+        Same-spin (alpha1 == alpha2) integrals are antisymmetrised; opposite-
+        spin integrals are not.
+
+        Parameters
+        ----------
+        C1 : ndarray, shape (nbsf, n1)
+            Orbital coefficients for electron 1 bra state.
+        C2 : ndarray, shape (nbsf, n2)
+            Orbital coefficients for electron 2 bra state.
+        C3 : ndarray, shape (nbsf, n3)
+            Orbital coefficients for electron 1 ket state.
+        C4 : ndarray, shape (nbsf, n4)
+            Orbital coefficients for electron 2 ket state.
+        alpha 1 : bool
+            Spin of electron 1. [True=alpha|False=beta]
+        alpha 2 : bool
+            Spin of electron 2. [True=alpha|False=beta]
+
+        Returns
+        -------
+        ndarray, shape (n1, n2, n3, n4)
+        """
+        return self._ints.tei_ao_to_mo(
+            np.asarray(C1, dtype=np.float64),
+            np.asarray(C2, dtype=np.float64),
+            np.asarray(C3, dtype=np.float64),
+            np.asarray(C4, dtype=np.float64),
+            alpha1, alpha2,
+        )
+
+    def tei_array(self, spin1=None, spin2=None) -> np.ndarray:
+        """Return the full two-electron integral array (pq|rs) in chemist's notation.
+
+        Parameters
+        ----------
+        spin1, spin2 : ignored
+            Included for API compatibility with PySCFIntegrals.
+
+        Returns
+        -------
+        ndarray, shape (nbsf, nbsf, nbsf, nbsf)
+        """
+        return self._ints.tei_array()
+
+    def mo_integrals(self, C: np.ndarray, ncore: int = 0, nactive: int = 0):
+        """Build a MOintegrals object for the (ncore, nactive) partition of C.
+
+        Parameters
+        ----------
+        C : ndarray, shape (nbsf, nmo)
+            Full orbital coefficient matrix.
+        ncore : int
+            Number of core (inactive) orbitals.
+        nactive : int
+            Number of active orbitals (defaults to nmo - ncore).
+
+        Returns
+        -------
+        MOintegrals
+        """
+        return self._ints.mo_integrals(np.asarray(C, dtype=np.float64), ncore, nactive)
+
+    def print(self):
+        """Print a summary of the FCIDUMP contents."""
+        print(f"  FCIDUMP file : {self.filename}")
+        print(f"  NORB         : {self.nbsf()}")
+        print(f"  NELEC        : {self.molecule().nelec()}  "
+              f"(nalpha={self.molecule().nalfa()}, nbeta={self.molecule().nbeta()})")
+        print(f"  Scalar pot.  : {self.scalar_potential(): .10f}")
+
+    def __str__(self):
+        return (
+            f"<quantel.ints.fcidump_integrals.FCIDUMP: "
+            f"norb={self.nbsf()}, nelec={self.molecule().nelec()}, file='{self.filename}'>"
+        )

--- a/quantel/ints/pyscf_integrals.py
+++ b/quantel/ints/pyscf_integrals.py
@@ -157,44 +157,65 @@ class PySCFIntegrals:
         return vJ[0]
     
     def build_JK(self,vdJ,vdK,hermi=0,Kxc=False):
-        """ Build Coulomb and Exchange matrices for multiple sets of densities
+        """ Build Coulomb and Exchange matrices for multiple sets of densities.
+
+        Returns batched 3D arrays (n, nbsf, nbsf) so the interface matches
+        the FCIDUMP backend: callers index the batch dimension with [i].
+
             Args:
-                vdJ : ndarray
-                    The Coulomb matrices
-                vdK : ndarray
-                    The Exchange matrices
+                vdJ : ndarray, shape (n, nbsf, nbsf) or (nbsf, nbsf)
+                    Density matrices for the Coulomb build.
+                vdK : ndarray, shape (n, nbsf, nbsf) or (nbsf, nbsf)
+                    Density matrices for the Exchange build.
                 hermi : int
                     0 if dm is not Hermitian, 1 if it is.
                 Kxc : bool
-                    Return the scaled exchange matrix for the xc functional if true
+                    Also return the xc-scaled exchange matrix.
             Returns:
-                ndarray : The Coulomb matrix
-                ndarray : The pure Exchange matrix
-                ndarray : The scaled Exchange matrix for xc functional
+                vJ  : ndarray, shape (nJ, nbsf, nbsf)
+                vK  : ndarray, shape (nK, nbsf, nbsf)
+                vKfunc (only when Kxc=True) : ndarray, shape (nK, nbsf, nbsf)
         """
-        vJ, vK = self.get_jk(dm=(vdJ,vdK), hermi=hermi)
-        vKfunc = vK
-        if (self.xc is None):
-            pass
-        elif self.ni.libxc.is_hybrid_xc(self.xc):
-            if(self.omega == 0):
+        vdJ = np.asarray(vdJ, dtype=np.float64)
+        vdK = np.asarray(vdK, dtype=np.float64)
+        if vdJ.ndim == 2: vdJ = vdJ[None]
+        if vdK.ndim == 2: vdK = vdK[None]
+
+        # Build J from vdJ and K from vdK separately so the batch sizes can
+        # differ and the indexing convention is unambiguous.
+        vJ, _ = self.get_jk(dm=vdJ, hermi=hermi, with_k=False)
+        _, vK = self.get_jk(dm=vdK, hermi=hermi, with_j=False)
+        vJ = np.asarray(vJ)
+        vK = np.asarray(vK)
+        if vJ.ndim == 2: vJ = vJ[None]
+        if vK.ndim == 2: vK = vK[None]
+
+        vKfunc = vK.copy()
+        if self.xc is not None and self.ni.libxc.is_hybrid_xc(self.xc):
+            if self.omega == 0:
                 vKfunc = vK * self.hybrid_K
             elif self.alpha == 0: # LR=0, only SR exchange
-                _, vKfunc = self.get_jk(dm=(vdJ,vdK), hermi=hermi, omega=-self.omega, with_j=False)
+                _, vKfunc = self.get_jk(dm=vdK, hermi=hermi, omega=-self.omega, with_j=False)
+                vKfunc = np.asarray(vKfunc)
+                if vKfunc.ndim == 2: vKfunc = vKfunc[None]
                 vKfunc *= self.hybrid_K
             elif self.hybrid_K == 0: # SR=0, only LR exchange
-                _, vKfunc = self.get_jk(dm=(vdJ,vdK), hermi=hermi, omega=self.omega, with_j=False)
-                vKfunc *= (self.alpha)
+                _, vKfunc = self.get_jk(dm=vdK, hermi=hermi, omega=self.omega, with_j=False)
+                vKfunc = np.asarray(vKfunc)
+                if vKfunc.ndim == 2: vKfunc = vKfunc[None]
+                vKfunc *= self.alpha
             else: # SR and LR different ratios
-                _, vKlr = self.get_jk(dm=(vdJ,vdK), hermi=hermi, omega=self.omega, with_j=False)
+                _, vKlr = self.get_jk(dm=vdK, hermi=hermi, omega=self.omega, with_j=False)
+                vKlr = np.asarray(vKlr)
+                if vKlr.ndim == 2: vKlr = vKlr[None]
                 vKfunc = vK * self.hybrid_K + (self.alpha - self.hybrid_K) * vKlr
-        else:
-            vKfunc *= 0
+        elif self.xc is not None:
+            vKfunc = np.zeros_like(vK)
 
         if Kxc:
-            return vJ[0], vK[1], vKfunc[1]
+            return vJ, vK, vKfunc
         else:
-            return vJ[0], vK[1]
+            return vJ, vK
 
     
     def build_vxc(self,dms,hermi=0):
@@ -351,7 +372,7 @@ class PySCF_MO_Integrals:
             Pcore = Ccore @ Ccore.T
             # Compute inactive JK matrix (2J-K) in AO basis
             J,K = self.ints.build_JK(Pcore,Pcore)
-            JK = 2*J - K
+            JK = 2*J[0] - K[0]
 
             # Compute scalar core energy 
             Hao = self.ints.oei_matrix()

--- a/quantel/ints/pyscf_integrals.py
+++ b/quantel/ints/pyscf_integrals.py
@@ -156,66 +156,44 @@ class PySCFIntegrals:
         vJ, _ = self.get_jk(dm=(vdJ,vdJ), hermi=hermi, with_k=False)
         return vJ[0]
     
-    def build_JK(self,vdJ,vdK,hermi=0,Kxc=False):
-        """ Build Coulomb and Exchange matrices for multiple sets of densities.
-
-        Returns batched 3D arrays (n, nbsf, nbsf) so the interface matches
-        the FCIDUMP backend: callers index the batch dimension with [i].
-
+    def build_JK(self,vd,hermi=0,Kxc=False):
+        """ Build Coulomb and Exchange matrices for multiple sets of densities
             Args:
-                vdJ : ndarray, shape (n, nbsf, nbsf) or (nbsf, nbsf)
-                    Density matrices for the Coulomb build.
-                vdK : ndarray, shape (n, nbsf, nbsf) or (nbsf, nbsf)
-                    Density matrices for the Exchange build.
+                vd : ndarray
+                    The density matrices
                 hermi : int
                     0 if dm is not Hermitian, 1 if it is.
                 Kxc : bool
-                    Also return the xc-scaled exchange matrix.
+                    Return the scaled exchange matrix for the xc functional if true
             Returns:
-                vJ  : ndarray, shape (nJ, nbsf, nbsf)
-                vK  : ndarray, shape (nK, nbsf, nbsf)
-                vKfunc (only when Kxc=True) : ndarray, shape (nK, nbsf, nbsf)
+                ndarray : The Coulomb matrix
+                ndarray : The pure Exchange matrix
+                ndarray : The scaled Exchange matrix for xc functional
         """
-        vdJ = np.asarray(vdJ, dtype=np.float64)
-        vdK = np.asarray(vdK, dtype=np.float64)
-        if vdJ.ndim == 2: vdJ = vdJ[None]
-        if vdK.ndim == 2: vdK = vdK[None]
-
-        # Build J from vdJ and K from vdK separately so the batch sizes can
-        # differ and the indexing convention is unambiguous.
-        vJ, _ = self.get_jk(dm=vdJ, hermi=hermi, with_k=False)
-        _, vK = self.get_jk(dm=vdK, hermi=hermi, with_j=False)
-        vJ = np.asarray(vJ)
-        vK = np.asarray(vK)
-        if vJ.ndim == 2: vJ = vJ[None]
-        if vK.ndim == 2: vK = vK[None]
-
-        vKfunc = vK.copy()
-        if self.xc is not None and self.ni.libxc.is_hybrid_xc(self.xc):
-            if self.omega == 0:
+        vJ, vK = self.get_jk(dm=vd, hermi=hermi)
+        vKfunc = vK
+        if (self.xc is None):
+            pass
+        elif self.ni.libxc.is_hybrid_xc(self.xc):
+            if(self.omega == 0):
                 vKfunc = vK * self.hybrid_K
             elif self.alpha == 0: # LR=0, only SR exchange
-                _, vKfunc = self.get_jk(dm=vdK, hermi=hermi, omega=-self.omega, with_j=False)
-                vKfunc = np.asarray(vKfunc)
-                if vKfunc.ndim == 2: vKfunc = vKfunc[None]
+                _, vKfunc = self.get_jk(dm=vd, hermi=hermi, omega=-self.omega, with_j=False)
                 vKfunc *= self.hybrid_K
             elif self.hybrid_K == 0: # SR=0, only LR exchange
-                _, vKfunc = self.get_jk(dm=vdK, hermi=hermi, omega=self.omega, with_j=False)
-                vKfunc = np.asarray(vKfunc)
-                if vKfunc.ndim == 2: vKfunc = vKfunc[None]
-                vKfunc *= self.alpha
+                _, vKfunc = self.get_jk(dm=vd, hermi=hermi, omega=self.omega, with_j=False)
+                vKfunc *= (self.alpha)
             else: # SR and LR different ratios
-                _, vKlr = self.get_jk(dm=vdK, hermi=hermi, omega=self.omega, with_j=False)
-                vKlr = np.asarray(vKlr)
-                if vKlr.ndim == 2: vKlr = vKlr[None]
+                _, vKlr = self.get_jk(dm=vd, hermi=hermi, omega=self.omega, with_j=False)
                 vKfunc = vK * self.hybrid_K + (self.alpha - self.hybrid_K) * vKlr
-        elif self.xc is not None:
-            vKfunc = np.zeros_like(vK)
+        else:
+            vKfunc *= 0
 
         if Kxc:
             return vJ, vK, vKfunc
         else:
             return vJ, vK
+
 
     
     def build_vxc(self,dms,hermi=0):
@@ -371,7 +349,7 @@ class PySCF_MO_Integrals:
             # Compute core density
             Pcore = Ccore @ Ccore.T
             # Compute inactive JK matrix (2J-K) in AO basis
-            J,K = self.ints.build_JK(Pcore,Pcore)
+            J,K = self.ints.build_JK(Pcore)
             JK = 2*J[0] - K[0]
 
             # Compute scalar core energy 

--- a/quantel/ints/utils.py
+++ b/quantel/ints/utils.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+
+import numpy as np
+
+def write_fcidump(integrals,mo_coeff:np.ndarray,filename:str="FCIDUMP",thresh=1e-15):
+    """Write an FCIDUMP file from any integral object.
+
+    Parameters
+    ----------
+    integrals : integral object
+        Any object exposing ``molecule()``, ``scalar_potential()``,
+        ``oei_ao_to_mo()``, and ``tei_ao_to_mo()`` (e.g. PySCFIntegrals or FCIDUMP).
+    filename : str
+        Output file path.
+    mo_coeff : ndarray of shape (nbsf, nmo)
+        MO coefficient matrix. Integrals are transformed to the MO basis before writing.
+    thresh : float, optional
+        Integral values with absolute value below this threshold are omitted.
+        Default is 1e-15.
+    """
+    # Get information from the integrals object
+    nalfa = integrals.molecule().nalfa()
+    nbeta = integrals.molecule().nbeta()
+    nelec = nalfa + nbeta
+    ms2 = nalfa - nbeta
+
+    # Get energy components
+    C = np.asarray(mo_coeff, dtype=np.float64)
+    norb = C.shape[1]
+    h = integrals.oei_ao_to_mo(C, C)
+    # tei_ao_to_mo returns physicist's <pq|rs>; opposite-spin (alpha1!=alpha2)
+    # gives no antisymmetrization. Convert to chemist's (pq|rs) = <pr|qs>
+    # via .transpose(0,2,1,3).
+    g = integrals.tei_ao_to_mo(C,C,C,C,True,False).transpose(0,2,1,3)
+
+    # Write the output file
+    with open(filename, 'w') as f:
+        # Header
+        orbsym = ','.join(['1'] * norb)
+        f.write(f" &FCI NORB={norb:<d}, NELEC={nelec:d}, MS2={ms2:d},\n")
+        f.write(f"  ORBSYM={orbsym},\n")
+        f.write(f"  ISYM=1,\n")
+        f.write(f" &END\n")
+
+        # Two-electron integrals (chemist's notation, 8-fold symmetry, 1-indexed)
+        # Loop over unique (pq|rs) with p>=q, r>=s, pq>=rs
+        for i in range(norb):
+            for j in range(i+1):
+                ij = i*norb + j
+                for k in range(norb):
+                    for l in range(k+1):
+                        kl = k*norb + l
+                        if ij < kl: continue
+                        val = g[i,j,k,l]
+                        if abs(val) > thresh:
+                            f.write(f"{val:23.16e} {i+1:4d} {j+1:4d} {k+1:4d} {l+1:4d}\n")
+
+        # One-electron integrals (upper triangle, 1-indexed)
+        for i in range(norb):
+            for j in range(i+1):
+                val = h[i,j]
+                if abs(val) > thresh:
+                    f.write(f"{val:23.16e} {i+1:4d} {j+1:4d} {0:4d} {0:4d}\n")
+
+        # Scalar potential (nuclear repulsion / frozen-core energy)
+        f.write(f"{integrals.scalar_potential():23.16e} {0:4d} {0:4d} {0:4d} {0:4d}\n")

--- a/quantel/opt/function.py
+++ b/quantel/opt/function.py
@@ -181,14 +181,21 @@ class Function(metaclass=ABCMeta):
         anl = self.gradient
         num = self.get_numerical_gradient()
         diff = anl - num
-        print(diff)
-        return np.linalg.norm(diff) / diff.size < tol
+        if(np.max(np.abs(diff)) > tol):
+            print("Gradient check failed!")
+            idx = np.unravel_index(np.argmax(np.abs(diff)), diff.shape)
+            print(f"Max difference at index {idx}: {diff[idx]:.3e}")
+        return np.max(np.abs(diff)) < tol
 
     def check_hessian(self, tol=1e-3):
         anl = self.hessian
         num = self.get_numerical_hessian()
         diff = anl - num
-        return np.linalg.norm(diff) / diff.size < tol
+        if(np.max(np.abs(diff)) > tol):
+            print("Hessian check failed!")
+            idx = np.unravel_index(np.argmax(np.abs(diff)), diff.shape)
+            print(f"Max difference at index {idx}: {diff[idx]:.3e}")
+        return np.max(np.abs(diff)) < tol
 
     def get_preconditioner(self):
         """Get diagonal preconditioner for Hessian"""

--- a/quantel/opt/function.py
+++ b/quantel/opt/function.py
@@ -130,7 +130,7 @@ class Function(metaclass=ABCMeta):
             else:         nzero +=1 
         return (ndown, nzero, nuphl)
 
-    def get_davidson_hessian_index(self, ntarget=5, eps=1e-5, approx_hess=True, plev=1):
+    def get_davidson_hessian_index(self, ntarget=5, eps=1e-5, approx_hess=True, plev=1, tol=1e-16):
         """Iteratively compute Hessian index from gradient only. 
            This approach uses the Davidson algorithm."""
         # Get approximate diagonal terms
@@ -159,13 +159,15 @@ class Function(metaclass=ABCMeta):
         # Count the Hessian index
         ndown = 0
         nzero = 0
+        nuphl = 0
         for i in eigs:
-            if i < -1e-16:  ndown += 1
-            elif not i>1e-16:  nzero +=1 
+            if i < -tol:  ndown += 1
+            elif i > tol: nuphl +=1
+            else:         nzero +=1 
 
         # Save the result
         self.hess_index = (ndown, nzero)
-        return
+        return (ndown, nzero, nuphl)
 
 
     def pushoff(self, n, angle=np.pi/2):
@@ -186,7 +188,6 @@ class Function(metaclass=ABCMeta):
         anl = self.hessian
         num = self.get_numerical_hessian()
         diff = anl - num
-        print(diff)
         return np.linalg.norm(diff) / diff.size < tol
 
     def get_preconditioner(self):

--- a/quantel/opt/hybrid_ef.py
+++ b/quantel/opt/hybrid_ef.py
@@ -136,7 +136,7 @@ class HybridEF:
                 if(plev>1): print("\n  ----------------------------------------------------------------")
                 if(plev>1): print("   Hybrid Eigenvector-Following step:")
                 if(plev>1): print("  ----------------------------------------------------------------")
-                print(" {: 5d} {: 16.10f}    {:^8s}    {:8.2e}    {:8.2e}    {:10s}".format(
+                if(plev>0): print(" {: 5d} {: 16.10f}    {:^8s}    {:8.2e}    {:8.2e}    {:10s}".format(
                       istep, eref, st_cur_ind, step_length, conv, comment))
                 if(plev>1): print("  ----------------------------------------------------------------")
 
@@ -144,7 +144,7 @@ class HybridEF:
                 if(plev>1): print("\n  ----------------------------------------------------------------")
                 if(plev>1): print("   Hybrid Eigenvector-Following step:")
                 if(plev>1): print("  ----------------------------------------------------------------")
-                print(" {: 5d} {: 16.10f}    {:^8s}                {:8.2e}    {:10s}".format(
+                if(plev>0): print(" {: 5d} {: 16.10f}    {:^8s}                {:8.2e}    {:10s}".format(
                     istep, eref, st_cur_ind, conv, comment))
                 if(plev>1): print("  ----------------------------------------------------------------")                
                 break

--- a/quantel/utils/csf_utils.py
+++ b/quantel/utils/csf_utils.py
@@ -258,24 +258,12 @@ def csf_reorder_orbitals(integrals, exchange_matrix, cinit, pop_method='becke'):
     if(exchange_matrix.shape[0] != nopen):
         raise RuntimeError("  Number of CSF orbitals does not match number of open-shell orbitals")
 
-    # Access the PySCF molecule object
-    pymol = integrals.molecule()
-
-    # Localise the active orbitals
-    print("  Localising open-shell orbitals")
-    pm = lo.PM(pymol, cinit, scf.ROHF(pymol))
-    pm.pop_method = pop_method
-    cinit = pm.kernel()
-
     # Get exchange integrals in active orbital space
-    print("  Computing localised orbital exchange integrals")
     vdm = np.einsum('pi,qi->ipq',cinit,cinit)
     vJ, vK = integrals.build_JK(vdm,vdm,Kxc=False)
     # Transform to MO basis
-    K = np.einsum('pmn,mq,nq->pq',vK,cinit,cinit)
-
+    K = np.einsum('pmn,mq,nq->pq',vK,cinit,cinit,optimize="optimal")
     # These are the active exchange integrals in chemists order (pq|rs)
-    print("  Optimising order of open-shell orbitals")
     order = optimise_order(K, exchange_matrix)
 
     # Save initial guess and return

--- a/quantel/utils/csf_utils.py
+++ b/quantel/utils/csf_utils.py
@@ -260,7 +260,7 @@ def csf_reorder_orbitals(integrals, exchange_matrix, cinit, pop_method='becke'):
 
     # Get exchange integrals in active orbital space
     vdm = np.einsum('pi,qi->ipq',cinit,cinit)
-    vJ, vK = integrals.build_JK(vdm,vdm,Kxc=False)
+    vJ, vK = integrals.build_JK(vdm,Kxc=False)
     # Transform to MO basis
     K = np.einsum('pmn,mq,nq->pq',vK,cinit,cinit,optimize="optimal")
     # These are the active exchange integrals in chemists order (pq|rs)

--- a/quantel/utils/linalg.py
+++ b/quantel/utils/linalg.py
@@ -174,7 +174,7 @@ def gram_schmidt(mat, metric=None):
     #            mat[:,i+1:mat.shape[1]] -=  np.outer(vi, np.einsum("i,ij,jk", vi, metric, mat[:,i+1:mat.shape[1]]))
     #return mat[:,idx_indep]
 
-def orthogonalise(mat, metric=None, thresh=1e-10, fill=True):
+def orthogonalise(mat, metric=None, thresh=1e-8, fill=True):
     '''
     Orthogonalise the columns of mat with respect to the metric tensor.
 
@@ -213,6 +213,9 @@ def orthogonalise(mat, metric=None, thresh=1e-10, fill=True):
 
         if(ortho_test > thresh):
             print(f"WARNING: Gram-Schmidt orthogonalisation failed with max(abs(error)) = {ortho_test: 7.3e}")
+            # Find where the error is coming from
+            x,y = np.unravel_index(np.argmax(np.abs(ortho)),ortho.shape)
+            print(f"Max error at ({x},{y}) = {ortho[x,y]: 7.3e}")
     return mat
  
 def matrix_print(M, title=None, labels=None, ncols=6, offset=0):

--- a/quantel/wfn/csf.py
+++ b/quantel/wfn/csf.py
@@ -230,6 +230,19 @@ class CSF(Wavefunction):
         nucl_dip, ao_dip = self.integrals.dipole_matrix()
         # Return the combination
         return nucl_dip - np.einsum('xij,kji->x',ao_dip,self.vd)
+    
+    def get_natural_orbitals(self):
+        """Compute spatial natural orbitals and their occupation numbers"""
+        X = self.integrals.orthogonalization_matrix()
+        # Get the spatial 1RDM in covariant form
+        dens = np.einsum('wpq->pq',self.vd)
+        # Project to linearly independent orbitals
+        Dt = np.linalg.multi_dot([X.T, dens, X])
+        # Diagonalise the Fock matrix
+        nocc, Ct = np.linalg.eigh(-Dt)
+        # Transform back to the original basis
+        Cno = np.dot(X, Ct)
+        return Cno, -nocc
 
     def tdm(self, them):
         """ Compute the transition dipole moment with another CSF state"""
@@ -451,51 +464,14 @@ class CSF(Wavefunction):
 
     def write_fcidump(self, tag):
         """ Write an FCIDUMP file for the current CSF object """
-        if(not (type(self.integrals) is quantel.ints.pyscf_integrals.PySCFIntegrals)):
-            raise ValueError("FCIDUMP file can only be written for PySCF integrals")
-        
-        # Write the FCIDUMP using PySCF
-        from pyscf.tools import fcidump
-        mol = self.integrals.molecule().copy()
-        mol.spin = int(2 * self.sz)
-        fcidump.from_mo(mol, tag+'.fcid', self.mo_coeff, ms=self.sz)
+        from quantel.ints.fcidump_integrals import write_fcidump
+        write_fcidump(self.integrals, tag+'.fcid', mo_coeff=self.mo_coeff)
 
     def write_cidump(self, tag):
         # Write the CI vector dump
         from quantel.utils.ci_utils import write_cidump
         write_cidump(get_csf_vector(self.spin_coupling),self.ncore,self.nbsf,tag+'_civec.txt')
 
-
-    def read_from_orca(self,json_file):
-        """ Read a set of CSF coefficients from ORCA gbw file.
-            This requires the orca_2json executable to be available and spin_coupling 
-            must be set in the Quantel input file.
-        """
-        import json
-        # Read ORCA Json file
-        with open(json_file, 'r') as f:
-            data = json.load(f)
-        mo_read = np.array([value['MOCoefficients'] for value in data['Molecule']['MolecularOrbitals']['MOs']]).T
-        
-        # TODO: For now, we have a temporary fix to change the sign of the f+3 and f-3 orbitals, 
-        #       which appear to be inconsistent between Libint and ORCA
-        orb_labels = data['Molecule']['MolecularOrbitals']['OrbitalLabels']
-        phase_shift = []
-        for i, l in enumerate(orb_labels):
-            if (r'f+3' in l) or (r'f-3' in l):
-                phase_shift.append(i)
-        mo_read[phase_shift,:] *= -1
-         
-        # Initialise the wave function
-        self.initialise(mo_read, spin_coupling=self.spin_coupling)   
-
-        # Check the input
-        if mo_read.shape[0] != self.nbsf:
-            raise ValueError("Inccorect number of AO basis functions in file")
-        if mo_read.shape[1] < self.nocc:
-            raise ValueError("Insufficient orbitals in file to represent occupied orbitals")
-        if mo_read.shape[1] > self.nmo:
-            raise ValueError("Too many orbitals in file")
 
     def read_from_disk(self, tag, override_spin_coupling=False):
         """Read a CSF wavefunction from disk with prefix 'tag'"""
@@ -529,23 +505,22 @@ class CSF(Wavefunction):
         return newcsf
 
     def overlap(self, them):
-        """ Compute the overlap between two CSF objects
-        """
+        """ Compute the overlap between two CSF objects"""
         ovlp = self.integrals.overlap_matrix()
         return csf_coupling(self, them, ovlp)[0]
 
 
     def hamiltonian(self, them):
-        """ Compute the Hamiltonian coupling between two CSF objects
-        """
+        """ Compute the Hamiltonian coupling between two CSF objects"""
         return csf_coupling_slater_condon(self, them, self.integrals)
     
 
-    def get_orbital_guess(self, method="gwh",avas_ao_labels=None,reorder=True, localise=True):
+    def get_orbital_guess(self, method="gwh",avas_ao_labels=None,reorder=True,localise=True):
         """Get a guess for the molecular orbital coefficients"""
         # Get the guess for the molecular orbital coefficients
-        Cguess = orbital_guess(self.integrals,method,avas_ao_labels=avas_ao_labels,rohf_ms=0.5*self.nopen)
-        if localise:  
+        if type(method)==np.ndarray:
+            Cguess = orthogonalise(method, self.integrals.overlap_matrix())
+        if localise:
             self.initialise(Cguess, spin_coupling=self.nopen*"+")
             self.localise_orbitals()
             Cguess = self.mo_coeff.copy() 

--- a/quantel/wfn/csf.py
+++ b/quantel/wfn/csf.py
@@ -464,7 +464,7 @@ class CSF(Wavefunction):
 
     def write_fcidump(self, tag):
         """ Write an FCIDUMP file for the current CSF object """
-        from quantel.ints.fcidump_integrals import write_fcidump
+        from quantel.ints.utils import write_fcidump
         write_fcidump(self.integrals, tag+'.fcid', mo_coeff=self.mo_coeff)
 
     def write_cidump(self, tag):

--- a/quantel/wfn/csf.py
+++ b/quantel/wfn/csf.py
@@ -520,6 +520,8 @@ class CSF(Wavefunction):
         # Get the guess for the molecular orbital coefficients
         if type(method)==np.ndarray:
             Cguess = orthogonalise(method, self.integrals.overlap_matrix())
+        else:
+            Cguess = orbital_guess(self.integrals,method,avas_ao_labels=avas_ao_labels,rohf_ms=0.5*self.nopen)
         if localise:
             self.initialise(Cguess, spin_coupling=self.nopen*"+")
             self.localise_orbitals()

--- a/quantel/wfn/csf.py
+++ b/quantel/wfn/csf.py
@@ -365,7 +365,7 @@ class CSF(Wavefunction):
                 vd[P+1] += self.beta[P,R] * np.linalg.multi_dot([self.mo_coeff[:,Rinds],step[Rinds,:],self.mo_coeff.T])
             vd[P+1] = 0.5 * (vd[P+1] + vd[P+1].T)
         # Build J and K matrices from first-order densities
-        J1, _, K1 = self.mo_transform(self.integrals.build_JK(vd,vd,hermi=1,Kxc=True))
+        J1, _, K1 = self.mo_transform(self.integrals.build_JK(vd,hermi=1,Kxc=True))
         # Contribution to Hvec
         Hvec += 4 * np.einsum('p,qp->pq',self.mo_occ,J1[0]) 
         # Don't include transpose as density was symmetrised
@@ -656,7 +656,7 @@ class CSF(Wavefunction):
         #    vJ = self.vJ_last + _vJ
         #    vK = self.vK_last + _vK
         #else:
-        vJ, _, vK = self.integrals.build_JK(vd,vd,hermi=1,Kxc=True)
+        vJ, _, vK = self.integrals.build_JK(vd,hermi=1,Kxc=True)
 
         # Save last elements
         self.vd_last = vd.copy()
@@ -827,7 +827,7 @@ class CSF(Wavefunction):
     def get_open_JK(self):
         """ Compute <pq|pq> and <pq|qp> for open-shell orbitals p"""
         vd = np.einsum('mp,np->pmn', self.mo_coeff[:,self.ncore:self.nocc], self.mo_coeff[:,self.ncore:self.nocc])
-        vJ, vK = self.integrals.build_JK(vd,vd,hermi=1,Kxc=False)
+        vJ, vK = self.integrals.build_JK(vd,hermi=1,Kxc=False)
         Ipqpq = np.einsum('pmn,mq,nq->pq', vJ, self.mo_coeff, self.mo_coeff, optimize='optimal')
         Ipqqp = np.einsum('pmn,mq,nq->pq', vK, self.mo_coeff, self.mo_coeff, optimize='optimal')
         return Ipqpq, Ipqqp 

--- a/quantel/wfn/ghf.py
+++ b/quantel/wfn/ghf.py
@@ -167,7 +167,7 @@ class GHF(Wavefunction):
         Dba = Dia[self.nbsf:,:self.nbsf]
         Dbb = Dia[self.nbsf:,self.nbsf:]
         # First order JK integrals
-        (Jaa,_,_,Jbb), (Kaa,Kab,Kba,Kbb) = self.integrals.build_JK([Daa,Dab,Dba,Dbb],[Daa,Dab,Dba,Dbb],hermi=0,Kxc=False)
+        (Jaa,_,_,Jbb), (Kaa,Kab,Kba,Kbb) = self.integrals.build_JK([Daa,Dab,Dba,Dbb],hermi=0,Kxc=False)
         Jia = np.zeros((2*self.nbsf, 2*self.nbsf))
         Jia[:self.nbsf,:self.nbsf] = Jaa + Jbb
         Jia[self.nbsf:,self.nbsf:] = Jaa + Jbb
@@ -273,7 +273,7 @@ class GHF(Wavefunction):
     def get_fock(self):
         """Compute the Fock matrix for the current state"""
         # Get JK integrals
-        self.vJ, self.vK = self.integrals.build_JK(self.vd,self.vd,Kxc=False,hermi=0)
+        self.vJ, self.vK = self.integrals.build_JK(self.vd,Kxc=False,hermi=0)
         # Construct the Coulomb matrix
         self.J = np.zeros((2*self.nbsf, 2*self.nbsf))
         self.J[:self.nbsf,:self.nbsf] = self.vJ[0] + self.vJ[2]

--- a/quantel/wfn/ghf.py
+++ b/quantel/wfn/ghf.py
@@ -247,12 +247,11 @@ class GHF(Wavefunction):
             return 0
         nocc = self.nocc
         S = np.linalg.multi_dot([self.mo_coeff[:,:nocc].T, self.ghf_overlap, them.mo_coeff[:,:nocc]])
-        return np.linalg.det(S)**2
+        return np.linalg.det(S)
 
     def hamiltonian(self, them):
-        """Compute the (nonorthogonal) many-body Hamiltonian coupling with another RHF wavefunction (them)"""
-        raise NotImplementedError("R" \
-        "HF Hamiltonian not implemented")
+        """Compute the (nonorthogonal) many-body Hamiltonian coupling with another GHF wavefunction (them)"""
+        raise NotImplementedError("GHF Hamiltonian not implemented")
 
     def update(self):
         """Update the 1RDM and Fock matrix for the current state"""
@@ -290,6 +289,24 @@ class GHF(Wavefunction):
         self.JK = self.J - self.K
         # Vectorised format of the Fock matrix 
         return self.fock.T.reshape((-1))
+    
+    def get_natural_orbitals(self):
+        """Compute spatial natural orbitals and their occupation numbers"""
+        # Overlap matrix and orthogonalisation matrix
+        S = self.integrals.overlap_matrix()
+        X = self.integrals.orthogonalization_matrix()
+
+        # Get the spatial 1RDM in covariant form
+        self.get_density()
+        Da = np.linalg.multi_dot([S, self.dens[:self.nbsf,:self.nbsf], S])
+        Db = np.linalg.multi_dot([S, self.dens[self.nbsf:,self.nbsf:], S]) 
+        # Project to linearly independent orbitals
+        Dt = np.linalg.multi_dot([X.T, Da + Db, X])
+        # Diagonalise the spatial density matrix
+        nocc, Ct = np.linalg.eigh(-Dt)
+        # Transform back to the original basis and return
+        Cno = np.dot(X, Ct)
+        return Cno, -nocc
 
 
     def canonicalize(self):
@@ -318,7 +335,7 @@ class GHF(Wavefunction):
         return Q
 
 
-    def get_preconditioner(self):
+    def get_preconditioner(self,abs=True):
         """Compute approximate diagonal of Hessian"""
         # Get Fock matrix in MO basis
         fock_mo = np.linalg.multi_dot([self.mo_coeff.T, self.fock, self.mo_coeff])
@@ -328,7 +345,10 @@ class GHF(Wavefunction):
         for p in range(self.nmo):
             for q in range(p):
                 Q[p,q] = 2 * (fock_mo[p,p] - fock_mo[q,q])
-        return np.abs(Q[self.rot_idx])
+        if abs:
+            return np.abs(Q[self.rot_idx])
+        else:
+            return Q[self.rot_idx]
 
 
     def diagonalise_fock(self):
@@ -510,7 +530,7 @@ class GHF(Wavefunction):
         return self.nelec - ev[-1]
     
     def excite(self,occ_idx,vir_idx,mom_method=None):
-        """ Perform orbital excitation on both spins
+        """ Perform orbital excitation
             Args:
                 occ_idx : list of occupied orbital indices to be excited
                 vir_idx : list of virtual orbital indices to be occupied
@@ -521,7 +541,7 @@ class GHF(Wavefunction):
         dest   = vir_idx + occ_idx
         coeff_new = self.mo_coeff.copy()
         coeff_new[:,dest] = self.mo_coeff[:,source]
-        them = GHF(self.integrals, verbose=self.verbose,mom_method=mom_method)
+        them = GHF(self.integrals,verbose=self.verbose,mom_method=mom_method)
         them.initialise(coeff_new)
         return them
 
@@ -537,4 +557,3 @@ class GHF(Wavefunction):
         # Saves MOs as cubegen files
         for mo in idx: 
             cubegen.orbital(self.integrals.mol, fname+f".mo.{mo}.cube", spatial[:,mo])
-

--- a/quantel/wfn/ghf.py
+++ b/quantel/wfn/ghf.py
@@ -83,7 +83,7 @@ class GHF(Wavefunction):
         # Two-electron energy
         E2 = 0.5 * np.einsum('pq,pq', self.JK, self.dens, optimize="optimal")
         # Save components
-        self.energy_components = dict(Nuclear=En, One_Electron=E1, Two_Electron=E2, Exchange_Correlation=0)
+        self.energy_components = dict(Nuclear=En, One_Electron=float(E1), Two_Electron=E2, Exchange_Correlation=0)
         return En + E1 + E2
 
     @property 
@@ -119,10 +119,10 @@ class GHF(Wavefunction):
         Fmo = np.linalg.multi_dot([self.mo_coeff.T, self.fock, self.mo_coeff])
 
         # Get occupied and virtual orbital coefficients
-        Cao = self.mo_coeff[:self.nbsf,:no].copy()
-        Cbo = self.mo_coeff[self.nbsf:,:no].copy()
-        Cav = self.mo_coeff[:self.nbsf,no:].copy()
-        Cbv = self.mo_coeff[self.nbsf:,no:].copy()
+        Cao = self.mo_coeff[:self.nbsf,:no]
+        Cbo = self.mo_coeff[self.nbsf:,:no]
+        Cav = self.mo_coeff[:self.nbsf,no:]
+        Cbv = self.mo_coeff[self.nbsf:,no:]
 
         # Compute ao_to_mo integral transform
         eri_abij = (  self.integrals.tei_ao_to_mo(Cav,Cav,Cao,Cao,True,False)
@@ -273,7 +273,7 @@ class GHF(Wavefunction):
     def get_fock(self):
         """Compute the Fock matrix for the current state"""
         # Get JK integrals
-        self.vJ, self.vK = self.integrals.build_JK(self.vd,self.vd,Kxc=False)
+        self.vJ, self.vK = self.integrals.build_JK(self.vd,self.vd,Kxc=False,hermi=0)
         # Construct the Coulomb matrix
         self.J = np.zeros((2*self.nbsf, 2*self.nbsf))
         self.J[:self.nbsf,:self.nbsf] = self.vJ[0] + self.vJ[2]
@@ -282,7 +282,7 @@ class GHF(Wavefunction):
         self.K = np.zeros((2*self.nbsf, 2*self.nbsf))
         self.K[:self.nbsf,:self.nbsf] = self.vK[0] # aa
         self.K[self.nbsf:,self.nbsf:] = self.vK[2] # bb
-        self.K[:self.nbsf,self.nbsf:] = self.vK[1] # ab
+        self.K[:self.nbsf,self.nbsf:] = self.vK[1] # ba
         self.K[self.nbsf:,:self.nbsf] = self.vK[1].T # ba
         # Compute the Coulomb and Exchange matrices
         self.fock = np.kron(np.eye(2), self.integrals.oei_matrix(True)) + self.J - self.K

--- a/quantel/wfn/rhf.py
+++ b/quantel/wfn/rhf.py
@@ -108,9 +108,12 @@ class RHF(Wavefunction):
         # Compute Fock matrix in MO basis 
         Fmo = np.linalg.multi_dot([self.mo_coeff.T, self.fock, self.mo_coeff])
 
-        # Get two-electron integrals if not already computed
-        if(not hasattr(self, 'eri_abij') or not hasattr(self, 'eri_aibj')):
-            self.update(with_eri=True)
+        # Get occupied and virtual orbital coefficients
+        Cocc = self.mo_coeff[:,:self.nocc].copy()
+        Cvir = self.mo_coeff[:,self.nocc:].copy()
+        # Compute ao_to_mo integral transform
+        eri_abij = self.integrals.tei_ao_to_mo(Cvir,Cvir,Cocc,Cocc,True,False)
+        eri_aibj = self.integrals.tei_ao_to_mo(Cvir,Cocc,Cvir,Cocc,True,False)
 
         # Initialise Hessian matrix
         hessian = np.zeros((nv,no,nv,no))
@@ -122,9 +125,9 @@ class RHF(Wavefunction):
             hessian[a,:,a,:] -= 4 * Fmo[:no,:no]
 
         # Compute two-electron contributions
-        hessian += 16 * np.einsum('abij->aibj', self.eri_abij, optimize="optimal")
-        hessian -=  4 * self.integrals.hybrid_K * np.einsum('ajbi->aibj', self.eri_aibj, optimize="optimal")
-        hessian -=  4 * self.integrals.hybrid_K * np.einsum('abji->aibj', self.eri_abij, optimize="optimal")
+        hessian += 16 * np.einsum('abij->aibj', eri_abij, optimize="optimal")
+        hessian -=  4 * self.integrals.hybrid_K * np.einsum('ajbi->aibj', eri_aibj, optimize="optimal")
+        hessian -=  4 * self.integrals.hybrid_K * np.einsum('abji->aibj', eri_abij, optimize="optimal")
 
         if(not (self.integrals.xc is None)):
             # Build ground-state density and xc kernel
@@ -252,17 +255,11 @@ class RHF(Wavefunction):
         """Compute the (nonorthogonal) many-body Hamiltonian coupling with another RHF wavefunction (them)"""
         raise NotImplementedError("RHF Hamiltonian not implemented")
 
-    def update(self, with_eri=False):
+    def update(self):
         """Update the 1RDM and Fock matrix for the current state"""
         self.get_density()
         self.get_fock()
-        if(with_eri):
-            # Get occupied and virtual orbital coefficients
-            Cocc = self.mo_coeff[:,:self.nocc].copy()
-            Cvir = self.mo_coeff[:,self.nocc:].copy()
-            # Compute ao_to_mo integral transform
-            self.eri_abij = self.integrals.tei_ao_to_mo(Cvir,Cvir,Cocc,Cocc,True,False)
-            self.eri_aibj = self.integrals.tei_ao_to_mo(Cvir,Cocc,Cvir,Cocc,True,False)
+
 
     def get_density(self):
         """Compute the 1RDM for the current state in AO basis"""

--- a/quantel/wfn/rhf.py
+++ b/quantel/wfn/rhf.py
@@ -86,6 +86,11 @@ class RHF(Wavefunction):
     def s2(self):
         """Get the spin of the current RHF state"""
         return 0 # All RHF states have spin 0
+    
+    @property
+    def sz(self):
+        """Get the S_z of the current RHF state"""
+        return 0 # All RHF states have S_z = 0
 
     @property
     def gradient(self):
@@ -267,7 +272,7 @@ class RHF(Wavefunction):
     def get_fock(self):
         """Compute the Fock matrix for the current state"""
         # Compute the Coulomb and Exchange matrices
-        J, self.Ipqqp, K = self.integrals.build_JK([self.dens],[self.dens],hermi=1,Kxc=True)
+        J, self.Ipqqp, K = self.integrals.build_JK(self.dens,self.dens,hermi=1,Kxc=True)
         self.JK = 2*J[0] - K[0]
         # Compute the exchange-correlation energy
         self.exc, self.vxc = self.integrals.build_vxc([self.dens, self.dens])

--- a/quantel/wfn/rhf.py
+++ b/quantel/wfn/rhf.py
@@ -161,7 +161,7 @@ class RHF(Wavefunction):
         # First order density change
         Dia = np.einsum('pa,ai,qi->pq', Ca, Xai, Ci, optimize="optimal")
         # Coulomb and exchange contributions
-        Jia, Kia, = self.integrals.build_JK([Dia],[Dia],hermi=0,Kxc=False)
+        Jia, Kia, = self.integrals.build_JK([Dia],hermi=0,Kxc=False)
         # Build ground-state density and fxc kernel
         if(not (self.integrals.xc is None)):
             occ = np.zeros(self.nmo)
@@ -269,7 +269,7 @@ class RHF(Wavefunction):
     def get_fock(self):
         """Compute the Fock matrix for the current state"""
         # Compute the Coulomb and Exchange matrices
-        J, self.Ipqqp, K = self.integrals.build_JK(self.dens,self.dens,hermi=1,Kxc=True)
+        J, self.Ipqqp, K = self.integrals.build_JK(self.dens,hermi=1,Kxc=True)
         self.JK = 2*J[0] - K[0]
         # Compute the exchange-correlation energy
         self.exc, self.vxc = self.integrals.build_vxc([self.dens, self.dens])

--- a/quantel/wfn/ss_casscf.py
+++ b/quantel/wfn/ss_casscf.py
@@ -329,7 +329,7 @@ class SS_CASSCF(Wavefunction):
         # Construct core potential outside active space
         dm_core = np.dot(self.mo_coeff[:,:self.ncore], self.mo_coeff[:,:self.ncore].T)
         v_j, v_k = self.integrals.build_JK(dm_core,dm_core)
-        v_jk = 2*v_j - v_k
+        v_jk = 2*v_j[0] - v_k[0]
         self.vhf_c = np.linalg.multi_dot([self.mo_coeff.T, v_jk, self.mo_coeff])
 
         # Reduced density matrices 

--- a/quantel/wfn/ss_casscf.py
+++ b/quantel/wfn/ss_casscf.py
@@ -328,7 +328,7 @@ class SS_CASSCF(Wavefunction):
         self.popo = self.integrals.tei_ao_to_mo(self.mo_coeff,self.mo_coeff,Cocc,Cocc,True,False).transpose(0,2,1,3)
         # Construct core potential outside active space
         dm_core = np.dot(self.mo_coeff[:,:self.ncore], self.mo_coeff[:,:self.ncore].T)
-        v_j, v_k = self.integrals.build_JK(dm_core,dm_core)
+        v_j, v_k = self.integrals.build_JK(dm_core)
         v_jk = 2*v_j[0] - v_k[0]
         self.vhf_c = np.linalg.multi_dot([self.mo_coeff.T, v_jk, self.mo_coeff])
 

--- a/quantel/wfn/uhf.py
+++ b/quantel/wfn/uhf.py
@@ -268,7 +268,7 @@ class UHF(Wavefunction):
     def get_fock(self): 
         """ Construct the two alpha and beta Fock matrices for the current iteration """
         # Compute arrays of J and K matrices
-        vJ, Ipqqp, vK = self.integrals.build_JK(self.dens,self.dens,Kxc=True)
+        vJ, Ipqqp, vK = self.integrals.build_JK(self.dens,Kxc=True)
         # Compute the exchange-correlation energy  
         self.exc , self.vxc = self.integrals.build_vxc(self.dens)
         # Compute JK contributions
@@ -563,7 +563,7 @@ class UHF(Wavefunction):
         D1a = np.einsum('pa,ai,qi->pq', Ca_alfa, Xai_alfa, Ci_alfa, optimize="optimal")
         D1b = np.einsum('pa,ai,qi->pq', Ca_beta, Xai_beta, Ci_beta, optimize="optimal")
         # Coulomb and exchange contributions
-        J, K = self.integrals.build_JK([D1a,D1b],[D1a,D1b], Kxc=False)
+        J, K = self.integrals.build_JK([D1a,D1b], Kxc=False)
         # Build ground-state density and xc kernel
         if(not (self.integrals.xc is None)):
             rho0, vxc, fxc = self.integrals.cache_xc_kernel(self.mo_coeff,self.mo_occ,spin=1)

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -20,26 +20,30 @@ using namespace pybind11::literals;
 
 py::array_t<double,py::array::c_style> vec_to_np_array(size_t d1, double *data)
 {
-     py::array_t<double,py::array::c_style> array(d1,data);
-     return array.reshape({d1});
+     py::array_t<double,py::array::c_style> array({(py::ssize_t)d1});
+     std::copy(data, data + d1, array.mutable_data());
+     return array;
 }
 
 py::array_t<double,py::array::c_style> vec_to_np_array(size_t d1, size_t d2, double *data)
 {
-     py::array_t<double,py::array::c_style> array(d1*d2,data);
-     return array.reshape({d1,d2});
+     py::array_t<double,py::array::c_style> array({(py::ssize_t)d1, (py::ssize_t)d2});
+     std::copy(data, data + d1*d2, array.mutable_data());
+     return array;
 }
 
 py::array_t<double,py::array::c_style> vec_to_np_array(size_t d1, size_t d2, size_t d3, double *data)
 {
-     py::array_t<double,py::array::c_style> array(d1*d2*d3,data);
-     return array.reshape({d1,d2,d3});
+     py::array_t<double,py::array::c_style> array({(py::ssize_t)d1, (py::ssize_t)d2, (py::ssize_t)d3});
+     std::copy(data, data + d1*d2*d3, array.mutable_data());
+     return array;
 }
 
 py::array_t<double,py::array::c_style> vec_to_np_array(size_t d1, size_t d2, size_t d3, size_t d4, double *data)
 {
-     py::array_t<double,py::array::c_style> array(d1*d2*d3*d4, data);
-     return array.reshape({d1,d2,d3,d4});
+     py::array_t<double,py::array::c_style> array({(py::ssize_t)d1, (py::ssize_t)d2, (py::ssize_t)d3, (py::ssize_t)d4});
+     std::copy(data, data + d1*d2*d3*d4, array.mutable_data());
+     return array;
 }
 
 bool libint_initialize() 
@@ -619,21 +623,35 @@ PYBIND11_MODULE(_quantel, m) {
                return vec_to_np_array(d1, d2, v_oei.data());
                }, "Transform one-electron integrals to a new orbital basis")
           .def("tei_ao_to_mo", [](FCIDumpInterface &ints,
-               py::array_t<double> &C1, py::array_t<double> &C2,
-               py::array_t<double> &C3, py::array_t<double> &C4,
-               bool alpha1, bool alpha2) {
-               auto b1 = C1.request(), b2 = C2.request();
-               auto b3 = C3.request(), b4 = C4.request();
-               size_t d1 = b1.shape[1], d2 = b2.shape[1];
-               size_t d3 = b3.shape[1], d4 = b4.shape[1];
-               std::vector<double> v_C1((double *) b1.ptr, (double *) b1.ptr + b1.size);
-               std::vector<double> v_C2((double *) b2.ptr, (double *) b2.ptr + b2.size);
-               std::vector<double> v_C3((double *) b3.ptr, (double *) b3.ptr + b3.size);
-               std::vector<double> v_C4((double *) b4.ptr, (double *) b4.ptr + b4.size);
-               std::vector<double> v_eri(d1 * d2 * d3 * d4, 0.0);
-               ints.tei_ao_to_mo(v_C1, v_C2, v_C3, v_C4, v_eri, alpha1, alpha2);
-               return vec_to_np_array(d1, d2, d3, d4, v_eri.data());
-               }, "Transform two-electron integrals to a new orbital basis (physicist, antisymmetrised)")
+               py::array_t<double> &C1, py::array_t<double> &C2, 
+               py::array_t<double> &C3, py::array_t<double> &C4, 
+               bool alpha1, bool alpha2) 
+               {
+                    size_t nbsf = ints.nbsf();
+                    // Get the buffer for the numpy arrays
+                    auto C1_buf = C1.request();
+                    auto C2_buf = C2.request();
+                    auto C3_buf = C3.request();
+                    auto C4_buf = C4.request();
+                    // Get the dimensions of the transformation matrices
+                    size_t d1 = C1_buf.shape[1];
+                    size_t d2 = C2_buf.shape[1];
+                    size_t d3 = C3_buf.shape[1];
+                    size_t d4 = C4_buf.shape[1];
+                    // Get the data from the numpy arrays
+                    std::vector<double> v_C1((double *) C1_buf.ptr, (double *) C1_buf.ptr + C1_buf.size);
+                    std::vector<double> v_C2((double *) C2_buf.ptr, (double *) C2_buf.ptr + C2_buf.size);
+                    std::vector<double> v_C3((double *) C3_buf.ptr, (double *) C3_buf.ptr + C3_buf.size);
+                    std::vector<double> v_C4((double *) C4_buf.ptr, (double *) C4_buf.ptr + C4_buf.size);
+                    // Allocate memory for the MO integrals
+                    std::vector<double> v_eri(d1*d2*d3*d4, 0.0);
+                    // Perform the transformation
+                    ints.tei_ao_to_mo(v_C1,v_C2,v_C3,v_C4,v_eri,alpha1,alpha2);
+                    // Return the MO integrals as a numpy array
+                    return vec_to_np_array(d1,d2,d3,d4,v_eri.data()); 
+               },
+               "Perform AO to MO transformation"
+          )
           .def("mo_integrals", [](FCIDumpInterface &ints,
                py::array_t<double> &C, size_t ncore, size_t nactive) {
                auto buf = C.request();

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -5,7 +5,8 @@
 #include <libint2/initialize.h>
 
 #include "libint_interface.h"
-#include "molecule.h"    
+#include "fcidump_interface.h"
+#include "molecule.h"
 #include "determinant.h"
 #include "mo_integrals.h"
 #include "excitation.h"
@@ -554,6 +555,91 @@ PYBIND11_MODULE(_quantel, m) {
                },
                "Return two-electron integral (pq|rs) array");
 
+
+     py::class_<FCIDumpInterface>(m, "FCIDumpInterface")
+          .def(py::init<const std::string &>(), "Construct from a FCIDUMP filename")
+          .def("nbsf",  &FCIDumpInterface::nbsf,  "Number of orbitals (NORB)")
+          .def("nmo",   &FCIDumpInterface::nmo,   "Number of molecular orbitals (= nbsf)")
+          .def("nelec", &FCIDumpInterface::nelec, "Total number of electrons (NELEC)")
+          .def("nalfa", &FCIDumpInterface::nalfa, "Number of alpha electrons")
+          .def("nbeta", &FCIDumpInterface::nbeta, "Number of beta electrons")
+          .def("scalar_potential", &FCIDumpInterface::scalar_potential,
+               "Scalar potential (nuclear repulsion or frozen-core energy)")
+          .def("overlap_matrix", [](FCIDumpInterface &ints) {
+               return vec_to_np_array(ints.nbsf(), ints.nbsf(), ints.overlap_matrix());
+               }, "Return the overlap matrix (identity)")
+          .def("orthogonalization_matrix", [](FCIDumpInterface &ints) {
+               return vec_to_np_array(ints.nbsf(), ints.nbsf(), ints.orthogonalization_matrix());
+               }, "Return the orthogonalisation matrix (identity)")
+          .def("oei_matrix", [](FCIDumpInterface &ints, bool alpha) {
+               return vec_to_np_array(ints.nbsf(), ints.nbsf(), ints.oei_matrix(alpha));
+               }, "Return the one-electron Hamiltonian matrix")
+          .def("tei_array", [](FCIDumpInterface &ints) {
+               size_t n = ints.nbsf();
+               return vec_to_np_array(n, n, n, n, ints.tei_array());
+               }, "Return the two-electron integral (pq|rs) array")
+          .def("build_fock", [](FCIDumpInterface &ints, py::array_t<double> &dens) {
+               size_t n = ints.nbsf();
+               auto buf = dens.request();
+               std::vector<double> v_dens((double *) buf.ptr, (double *) buf.ptr + buf.size);
+               std::vector<double> v_fock(v_dens.size(), 0.0);
+               ints.build_fock(v_dens, v_fock);
+               return vec_to_np_array(n, n, v_fock.data());
+               }, "Build Fock matrix from restricted density matrix")
+          .def("build_JK", [](FCIDumpInterface &ints, py::array_t<double> &dens) {
+               size_t n = ints.nbsf();
+               auto buf = dens.request();
+               std::vector<double> v_dens((double *) buf.ptr, (double *) buf.ptr + buf.size);
+               std::vector<double> v_jk(v_dens.size(), 0.0);
+               ints.build_JK(v_dens, v_jk);
+               return vec_to_np_array(n, n, v_jk.data());
+               }, "Build (2J-K) matrix from density matrix")
+          .def("build_multiple_JK", [](FCIDumpInterface &ints,
+                    py::array_t<double> &vDJ, py::array_t<double> &vDK,
+                    size_t nj, size_t nk) {
+               size_t nbsf = ints.nbsf();
+               auto bJ_buf = vDJ.request();
+               auto bK_buf = vDK.request();
+               std::vector<double> v_vDJ((double *) bJ_buf.ptr, (double *) bJ_buf.ptr + bJ_buf.size);
+               std::vector<double> v_vDK((double *) bK_buf.ptr, (double *) bK_buf.ptr + bK_buf.size);
+               std::vector<double> v_J(nbsf*nbsf*nj, 0.0), v_K(nbsf*nbsf*nk, 0.0);
+               ints.build_multiple_JK(v_vDJ,v_vDK,v_J,v_K,nj,nk);
+               return std::make_tuple(
+                    vec_to_np_array(nj,nbsf,nbsf,v_J.data()),
+                    vec_to_np_array(nk,nbsf,nbsf,v_K.data()));
+               }, "Build J and K matrices for multiple density matrices")
+          .def("oei_ao_to_mo", [](FCIDumpInterface &ints,
+               py::array_t<double> &C1, py::array_t<double> &C2, bool alpha) {
+               auto b1 = C1.request(), b2 = C2.request();
+               size_t d1 = b1.shape[1], d2 = b2.shape[1];
+               std::vector<double> v_C1((double *) b1.ptr, (double *) b1.ptr + b1.size);
+               std::vector<double> v_C2((double *) b2.ptr, (double *) b2.ptr + b2.size);
+               std::vector<double> v_oei(d1 * d2, 0.0);
+               ints.oei_ao_to_mo(v_C1, v_C2, v_oei, alpha);
+               return vec_to_np_array(d1, d2, v_oei.data());
+               }, "Transform one-electron integrals to a new orbital basis")
+          .def("tei_ao_to_mo", [](FCIDumpInterface &ints,
+               py::array_t<double> &C1, py::array_t<double> &C2,
+               py::array_t<double> &C3, py::array_t<double> &C4,
+               bool alpha1, bool alpha2) {
+               auto b1 = C1.request(), b2 = C2.request();
+               auto b3 = C3.request(), b4 = C4.request();
+               size_t d1 = b1.shape[1], d2 = b2.shape[1];
+               size_t d3 = b3.shape[1], d4 = b4.shape[1];
+               std::vector<double> v_C1((double *) b1.ptr, (double *) b1.ptr + b1.size);
+               std::vector<double> v_C2((double *) b2.ptr, (double *) b2.ptr + b2.size);
+               std::vector<double> v_C3((double *) b3.ptr, (double *) b3.ptr + b3.size);
+               std::vector<double> v_C4((double *) b4.ptr, (double *) b4.ptr + b4.size);
+               std::vector<double> v_eri(d1 * d2 * d3 * d4, 0.0);
+               ints.tei_ao_to_mo(v_C1, v_C2, v_C3, v_C4, v_eri, alpha1, alpha2);
+               return vec_to_np_array(d1, d2, d3, d4, v_eri.data());
+               }, "Transform two-electron integrals to a new orbital basis (physicist, antisymmetrised)")
+          .def("mo_integrals", [](FCIDumpInterface &ints,
+               py::array_t<double> &C, size_t ncore, size_t nactive) {
+               auto buf = C.request();
+               std::vector<double> v_C((double *) buf.ptr, (double *) buf.ptr + buf.size);
+               return ints.mo_integrals(v_C, ncore, nactive);
+               }, "Build MOintegrals for the (ncore, nactive) orbital partition of C");
 
      m.def("det_str", &det_str,"Print the determinant");
 

--- a/src/fcidump_interface.cpp
+++ b/src/fcidump_interface.cpp
@@ -1,0 +1,543 @@
+#include <omp.h>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include "fcidump_interface.h"
+#include "linalg.h"
+#include "omp_device.h"
+
+void FCIDumpInterface::initialize(const std::string &filename)
+{
+    parse_fcidump(filename);
+}
+
+namespace {
+
+/// Return an uppercase copy of s
+std::string to_upper(std::string s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+    return s;
+}
+
+/// Parse the integer value for key KEY= from a header string (upper-case).
+/// Returns -1 when the key is absent.
+long parse_header_int(const std::string &upper_header, const std::string &key)
+{
+    std::string tok = key + "=";
+    size_t pos = upper_header.find(tok);
+    if (pos == std::string::npos) return -1;
+    pos += tok.size();
+    // Skip optional whitespace
+    while (pos < upper_header.size() && std::isspace(upper_header[pos])) ++pos;
+    // Collect digits (and optional leading minus)
+    std::string numstr;
+    if (pos < upper_header.size() && upper_header[pos] == '-') numstr += upper_header[pos++];
+    while (pos < upper_header.size() && std::isdigit(upper_header[pos]))
+        numstr += upper_header[pos++];
+    return numstr.empty() ? -1 : std::stol(numstr);
+}
+
+} // anonymous namespace
+
+void FCIDumpInterface::parse_fcidump(const std::string &filename)
+{
+    std::ifstream file(filename);
+    if (!file.is_open())
+        throw std::runtime_error("FCIDumpInterface: cannot open file '" + filename + "'");
+
+    // -----------------------------------------------------------------------
+    // 1. Read the header block
+    // -----------------------------------------------------------------------
+    std::string line;
+    std::string header;          // accumulated header text (stripped of &FCI / &END)
+    bool in_header = false;
+
+    while (std::getline(file, line))
+    {
+        std::string upper = to_upper(line);
+
+        if (!in_header)
+        {
+            if (upper.find("&FCI") != std::string::npos)
+            {
+                in_header = true;
+                // Keep the part after &FCI on the same line
+                size_t pos = upper.find("&FCI") + 4;
+                header += line.substr(pos) + " ";
+            }
+            continue;
+        }
+
+        // Check for end-of-header markers
+        // '/' alone on a line (possibly surrounded by whitespace) or &END anywhere
+        std::string stripped = line;
+        stripped.erase(
+            std::remove_if(stripped.begin(), stripped.end(), ::isspace),
+            stripped.end());
+
+        if (stripped == "/" || upper.find("&END") != std::string::npos)
+        {
+            in_header = false;
+            break;
+        }
+
+        header += line + " ";
+    }
+
+    if (in_header)
+        throw std::runtime_error("FCIDumpInterface: end of header (&END or /) not found in '" + filename + "'");
+
+    // -----------------------------------------------------------------------
+    // 2. Parse NORB, NELEC, MS2 from header
+    // -----------------------------------------------------------------------
+    std::string upper_header = to_upper(header);
+
+    long norb  = parse_header_int(upper_header, "NORB");
+    long nelec = parse_header_int(upper_header, "NELEC");
+    long ms2   = parse_header_int(upper_header, "MS2");
+
+    if (norb  <= 0) throw std::runtime_error("FCIDumpInterface: NORB not found or invalid");
+    if (nelec < 0)  throw std::runtime_error("FCIDumpInterface: NELEC not found or invalid");
+
+    m_nbsf  = static_cast<size_t>(norb);
+    m_nmo   = m_nbsf;
+    m_nelec = static_cast<size_t>(nelec);
+    m_ms2   = (ms2 >= 0) ? static_cast<size_t>(ms2) : 0;
+
+    // -----------------------------------------------------------------------
+    // 3. Allocate and initialise storage
+    // -----------------------------------------------------------------------
+    size_t n2 = m_nbsf * m_nbsf;
+    size_t n4 = n2 * n2;
+
+    m_V = 0.0;
+
+    m_S.assign(n2, 0.0);
+    m_X.assign(n2, 0.0);
+    for (size_t p = 0; p < m_nbsf; p++)
+    {
+        m_S[p*m_nbsf+p] = 1.0;
+        m_X[p*m_nbsf+p] = 1.0;
+    }
+
+    m_oei_a.assign(n2, 0.0);
+    m_oei_b.assign(n2, 0.0);
+    m_tei.assign(n4, 0.0);
+
+    // -----------------------------------------------------------------------
+    // 4. Read integral data lines
+    // -----------------------------------------------------------------------
+    while (std::getline(file, line))
+    {
+        if (line.empty()) continue;
+
+        // Fortran scientific notation: replace D/d exponent markers with E/e
+        std::replace(line.begin(), line.end(), 'D', 'E');
+        std::replace(line.begin(), line.end(), 'd', 'e');
+
+        std::istringstream iss(line);
+        double value;
+        long   i, j, k, l;
+
+        if (!(iss >> value >> i >> j >> k >> l)) continue;
+
+        if (i == 0 && j == 0 && k == 0 && l == 0)
+        {
+            // Scalar potential (nuclear repulsion or frozen-core energy)
+            m_V = value;
+        }
+        else if (k == 0 && l == 0)
+        {
+            // One-electron integral h(i,j) — 1-indexed, symmetric
+            size_t pi = static_cast<size_t>(i) - 1;
+            size_t pj = static_cast<size_t>(j) - 1;
+            m_oei_a[pi*m_nbsf+pj] = value;
+            m_oei_a[pj*m_nbsf+pi] = value;
+            m_oei_b[pi*m_nbsf+pj] = value;
+            m_oei_b[pj*m_nbsf+pi] = value;
+        }
+        else
+        {
+            // Save value in chemists notation and apply 8 fold symmetry (ij|kl)=<ik|jl>
+            size_t pi = static_cast<size_t>(i) - 1;
+            size_t pj = static_cast<size_t>(j) - 1;
+            size_t pk = static_cast<size_t>(k) - 1;
+            size_t pl = static_cast<size_t>(l) - 1;
+
+            m_tei[tei_index(pi,pj,pk,pl)] = value;
+            m_tei[tei_index(pj,pi,pk,pl)] = value;
+            m_tei[tei_index(pi,pj,pl,pk)] = value;
+            m_tei[tei_index(pj,pi,pl,pk)] = value;
+            m_tei[tei_index(pk,pl,pi,pj)] = value;
+            m_tei[tei_index(pl,pk,pi,pj)] = value;
+            m_tei[tei_index(pk,pl,pj,pi)] = value;
+            m_tei[tei_index(pl,pk,pj,pi)] = value;
+        }
+    }
+}
+
+void FCIDumpInterface::build_fock(
+    std::vector<double> &dens, std::vector<double> &fock)
+{
+    size_t n2 = m_nbsf * m_nbsf;
+    assert(dens.size() == n2);
+
+    build_JK(dens, fock);
+
+    #pragma omp parallel for
+    for (size_t pq = 0; pq < n2; pq++)
+        fock[pq] += m_oei_a[pq];
+}
+
+void FCIDumpInterface::build_JK(
+    std::vector<double> &dens, std::vector<double> &JK)
+{
+    size_t n2 = m_nbsf * m_nbsf;
+    assert(dens.size() == n2);
+
+    JK.resize(n2);
+    std::fill(JK.begin(), JK.end(), 0.0);
+
+    omp_device dev;
+    std::vector<double> Jt(dev.nthreads*n2), Kt(dev.nthreads*n2);
+    std::fill(Jt.begin(),Jt.end(),0.0);
+    std::fill(Kt.begin(),Kt.end(),0.0);
+
+    #pragma omp parallel for collapse(2) schedule(guided)
+    for (size_t p=0; p<m_nbsf; p++)
+    for (size_t r=0; r<m_nbsf; r++)
+    {
+        int ithread = dev.thread_id();
+        double *J = &Jt[ithread*n2];
+        double *K = &Kt[ithread*n2];
+
+        for (size_t q=p; q<m_nbsf; q++)
+        for (size_t s=r; s<m_nbsf; s++)
+        {
+            size_t pq = p*m_nbsf+q;
+            size_t rs = r*m_nbsf+s;
+            if (pq > rs) continue;
+
+            double Vpqrs = m_tei[pq*n2+rs];
+            if (std::abs(Vpqrs) < thresh) continue;
+
+            J[p*m_nbsf+q] += dens[r*m_nbsf+s] * Vpqrs;
+            K[p*m_nbsf+s] += dens[r*m_nbsf+q] * Vpqrs;
+            if (p != q) {
+                J[q*m_nbsf+p] += dens[r*m_nbsf+s] * Vpqrs;
+                K[q*m_nbsf+s] += dens[r*m_nbsf+p] * Vpqrs;
+            }
+            if (r != s) {
+                J[p*m_nbsf+q] += dens[s*m_nbsf+r] * Vpqrs;
+                K[p*m_nbsf+r] += dens[s*m_nbsf+q] * Vpqrs;
+            }
+            if (r != s && p != q) {
+                J[q*m_nbsf+p] += dens[s*m_nbsf+r] * Vpqrs;
+                K[q*m_nbsf+r] += dens[s*m_nbsf+p] * Vpqrs;
+            }
+
+            if (pq != rs)
+            {
+                J[r*m_nbsf+s] += dens[p*m_nbsf+q] * Vpqrs;
+                K[r*m_nbsf+q] += dens[p*m_nbsf+s] * Vpqrs;
+                if (r != s) {
+                    J[s*m_nbsf+r] += dens[p*m_nbsf+q] * Vpqrs;
+                    K[s*m_nbsf+q] += dens[p*m_nbsf+r] * Vpqrs;
+                }
+                if (p != q) {
+                    J[r*m_nbsf+s] += dens[q*m_nbsf+p] * Vpqrs;
+                    K[r*m_nbsf+p] += dens[q*m_nbsf+s] * Vpqrs;
+                }
+                if (r != s && p != q) {
+                    J[s*m_nbsf+r] += dens[q*m_nbsf+p] * Vpqrs;
+                    K[s*m_nbsf+p] += dens[q*m_nbsf+r] * Vpqrs;
+                }
+            }
+        }
+    }
+
+    // Consolidate date from different threads
+    for (size_t it=0; it<dev.nthreads; it++)
+    for (size_t pq=0; pq<n2; pq++)
+        JK[pq] += 2.0 * Jt[it*n2+pq] - Kt[it*n2+pq];
+}
+
+void FCIDumpInterface::build_multiple_JK(
+    std::vector<double> &vDJ, std::vector<double> &vDK,
+    std::vector<double> &vJ,  std::vector<double> &vK,
+    size_t nj, size_t nk)
+{
+    // Get size of n2 for indexing later
+    size_t n2 = m_nbsf * m_nbsf;
+
+    // Check dimensions of density matrix
+    assert(vDJ.size() == nj * n2);
+    // Check dimensions of exchange matrices
+    assert(vDK.size() == nk * n2);
+
+    // Resize J matrix
+    vJ.resize(nj*n2);
+    std::fill(vJ.begin(),vJ.end(),0.0);
+    // Resize K matrices
+    vK.resize(nk*n2);
+    std::fill(vK.begin(),vK.end(),0.0);
+
+    // Setup thread-safe memory
+    omp_device dev;
+    std::vector<double> Jsafe(dev.nthreads*n2*nj), Ksafe(dev.nthreads*n2*nk);
+    std::fill(Jsafe.begin(),Jsafe.end(),0.0);
+    std::fill(Ksafe.begin(),Ksafe.end(),0.0);
+
+    // Loop over basis functions
+    #pragma omp parallel for collapse(2) schedule(guided)
+    for(size_t p=0; p<m_nbsf; p++)
+    for(size_t r=0; r<m_nbsf; r++)
+    {
+        int ithread = dev.thread_id();
+        double *Jt = &Jsafe[ithread*n2*nj];
+        double *Kt = &Ksafe[ithread*n2*nk];
+
+        for(size_t q=p; q<m_nbsf; q++)
+        for(size_t s=r; s<m_nbsf; s++)
+        {
+            size_t pq = p*m_nbsf+q;
+            size_t rs = r*m_nbsf+s;
+            if(pq > rs) continue;
+
+            // Skip if below threshold
+            double Vpqrs = m_tei[pq*n2+rs];
+            if(std::abs(Vpqrs) < thresh) continue;
+
+            // Compute J matrix elements (need to repeat for each density)
+            for(size_t k=0; k < nj; k++)
+            {
+                double *Jt_k = &Jt[k*n2];
+                double *Dj   = &vDJ[k*n2];
+                Jt_k[p*m_nbsf+q] += Dj[r*m_nbsf+s] * Vpqrs;
+                if(p!=q) Jt_k[q*m_nbsf+p] += Dj[r*m_nbsf+s] * Vpqrs;
+                if(r!=s) Jt_k[p*m_nbsf+q] += Dj[s*m_nbsf+r] * Vpqrs;
+                if(r!=s and p!=q) Jt_k[q*m_nbsf+p] += Dj[s*m_nbsf+r] * Vpqrs;
+
+                if(pq != rs) 
+                {
+                    Jt_k[r*m_nbsf+s] += Dj[p*m_nbsf+q] * Vpqrs;
+                    if(r!=s) Jt_k[s*m_nbsf+r] += Dj[p*m_nbsf+q] * Vpqrs;
+                    if(p!=q) Jt_k[r*m_nbsf+s] += Dj[q*m_nbsf+p] * Vpqrs;
+                    if(r!=s and p!=q) Jt_k[s*m_nbsf+r] += Dj[q*m_nbsf+p] * Vpqrs;
+                }                
+            }
+
+            // Compute K matrix elements (need to repeat for each density)
+            for(size_t k=0; k < nk; k++)
+            {
+                double *Kt_k = &Kt[k*n2];
+                double *Dk   = &vDK[k*n2];
+                Kt_k[p*m_nbsf+s] += Dk[r*m_nbsf+q] * Vpqrs;
+                if(p!=q) Kt_k[q*m_nbsf+s] += Dk[r*m_nbsf+p] * Vpqrs;
+                if(r!=s) Kt_k[p*m_nbsf+r] += Dk[s*m_nbsf+q] * Vpqrs;
+                if(r!=s and p!=q) Kt_k[q*m_nbsf+r] += Dk[s*m_nbsf+p] * Vpqrs;
+
+                if(pq != rs) 
+                {
+                    Kt_k[r*m_nbsf+q] += Dk[p*m_nbsf+s] * Vpqrs;
+                    if(r!=s) Kt_k[s*m_nbsf+q] += Dk[p*m_nbsf+r] * Vpqrs;
+                    if(p!=q) Kt_k[r*m_nbsf+p] += Dk[q*m_nbsf+s] * Vpqrs;
+                    if(r!=s and p!=q) Kt_k[s*m_nbsf+p] += Dk[q*m_nbsf+r] * Vpqrs;
+                }
+            }
+        }
+    }
+
+    // Collect values for each thread
+    for(size_t it=0; it < dev.nthreads; it++)
+    {
+        for(size_t pqk=0; pqk < n2 * nj; pqk++)
+            vJ[pqk] += Jsafe[it*n2*nj+pqk];
+        for(size_t pqk=0; pqk < n2 * nk; pqk++)
+            vK[pqk] += Ksafe[it*n2*nk+pqk];
+    }
+}
+
+void FCIDumpInterface::oei_ao_to_mo(
+    std::vector<double> &C1, std::vector<double> &C2,
+    std::vector<double> &oei_mo, bool alpha)
+{
+    assert(C1.size() % m_nbsf == 0);
+    assert(C2.size() % m_nbsf == 0);
+
+    size_t d1 = C1.size() / m_nbsf;
+    size_t d2 = C2.size() / m_nbsf;
+
+    std::vector<double> &oei = alpha ? m_oei_a : m_oei_b;
+    oei_transform(C1, C2, oei, oei_mo, d1, d2, m_nbsf);
+}
+
+void FCIDumpInterface::tei_ao_to_mo(
+    std::vector<double> &C1, std::vector<double> &C2,
+    std::vector<double> &C3, std::vector<double> &C4,
+    std::vector<double> &eri, bool alpha1, bool alpha2)
+{
+    size_t n2 = m_nbsf * m_nbsf;
+
+    assert(C1.size() % m_nbsf == 0);
+    assert(C2.size() % m_nbsf == 0);
+    assert(C3.size() % m_nbsf == 0);
+    assert(C4.size() % m_nbsf == 0);
+
+    size_t d1 = C1.size() / m_nbsf;
+    size_t d2 = C2.size() / m_nbsf;
+    size_t d3 = C3.size() / m_nbsf;
+    size_t d4 = C4.size() / m_nbsf;
+
+    std::vector<double> tmp1(n2 * n2, 0.0);
+    std::vector<double> tmp2(n2 * n2, 0.0);
+
+    // Antisymmetrise and convert chemist's → physicist's: <mn||st> = (ms|nt) - (mt|ns)
+    double scale = (alpha1 == alpha2) ? 1.0 : 0.0;
+    #pragma omp parallel for collapse(4)
+    for (size_t mu = 0; mu < m_nbsf; mu++)
+    for (size_t nu = 0; nu < m_nbsf; nu++)
+    for (size_t sg = 0; sg < m_nbsf; sg++)
+    for (size_t ta = 0; ta < m_nbsf; ta++)
+    {
+        size_t i1 = (mu*m_nbsf+nu)*n2 + sg*m_nbsf+ta;
+        size_t i2 = (mu*m_nbsf+sg)*n2 + nu*m_nbsf+ta;
+        size_t i3 = (mu*m_nbsf+ta)*n2 + nu*m_nbsf+sg;
+        tmp2[i1] = m_tei[i2] - scale * m_tei[i3];
+    }
+
+    // Transform s index
+    #pragma omp parallel for collapse(2)
+    for (size_t mu = 0; mu < m_nbsf; mu++)
+    for (size_t nu = 0; nu < m_nbsf; nu++)
+    {
+        double *buff1 = &tmp2[mu*m_nbsf*m_nbsf*m_nbsf + nu*m_nbsf*m_nbsf];
+        double *buff2 = &tmp1[mu*m_nbsf*m_nbsf*d4     + nu*m_nbsf*d4];
+        for (size_t sg = 0; sg < m_nbsf; sg++)
+        for (size_t ta = 0; ta < m_nbsf; ta++)
+        {
+            double Iv = buff1[sg*m_nbsf+ta];
+            if (std::abs(Iv) < thresh) continue;
+            for (size_t s = 0; s < d4; s++)
+                buff2[sg*d4+s] += Iv * C4[ta*d4+s];
+        }
+    }
+
+    // Transform r index
+    std::fill(tmp2.begin(), tmp2.end(), 0.0);
+    #pragma omp parallel for collapse(2)
+    for (size_t mu = 0; mu < m_nbsf; mu++)
+    for (size_t nu = 0; nu < m_nbsf; nu++)
+    {
+        double *buff1 = &tmp1[mu*m_nbsf*m_nbsf*d4 + nu*m_nbsf*d4];
+        double *buff2 = &tmp2[mu*m_nbsf*d3*d4     + nu*d3*d4];
+        for (size_t sg = 0; sg < m_nbsf; sg++)
+        for (size_t s  = 0; s  < d4;     s++)
+        {
+            double Iv = buff1[sg*d4+s];
+            if (std::abs(Iv) < thresh) continue;
+            for (size_t r = 0; r < d3; r++)
+                buff2[r*d4+s] += Iv * C3[sg*d3+r];
+        }
+    }
+
+    // Transform q index
+    std::fill(tmp1.begin(), tmp1.end(), 0.0);
+    #pragma omp parallel for collapse(2)
+    for (size_t mu = 0; mu < m_nbsf; mu++)
+    for (size_t q  = 0; q  < d2;     q++)
+    {
+        double *buff1 = &tmp2[mu*m_nbsf*d3*d4];
+        double *buff2 = &tmp1[mu*d2*d3*d4 + q*d3*d4];
+        for (size_t nu = 0; nu < m_nbsf; nu++)
+        for (size_t r  = 0; r  < d3;     r++)
+        for (size_t s  = 0; s  < d4;     s++)
+        {
+            double Iv = buff1[nu*d3*d4 + r*d4+s];
+            if (std::abs(Iv) < thresh) continue;
+            buff2[r*d4+s] += Iv * C2[nu*d2+q];
+        }
+    }
+
+    // Transform p index
+    eri.assign(d1 * d2 * d3 * d4, 0.0);
+    #pragma omp parallel for collapse(2)
+    for (size_t p = 0; p < d1; p++)
+    for (size_t q = 0; q < d2; q++)
+    {
+        double *buff1 = &eri[p*d2*d3*d4 + q*d3*d4];
+        for (size_t mu = 0; mu < m_nbsf; mu++)
+        {
+            double *buff2 = &tmp1[mu*d2*d3*d4];
+            for (size_t r = 0; r < d3; r++)
+            for (size_t s = 0; s < d4; s++)
+            {
+                double Iv = buff2[q*d3*d4 + r*d4+s];
+                if (std::abs(Iv) < thresh) continue;
+                buff1[r*d4+s] += Iv * C1[mu*d1+p];
+            }
+        }
+    }
+}
+
+
+MOintegrals FCIDumpInterface::mo_integrals(
+    std::vector<double> &C, size_t ncore, size_t nactive)
+{
+    if (nactive == 0) nactive = m_nmo - ncore;
+
+    if (C.size() == 0)
+        throw std::runtime_error("FCIDumpInterface::mo_integrals: no orbital coefficients provided");
+    if (C.size() != m_nbsf * m_nmo)
+        throw std::runtime_error("FCIDumpInterface::mo_integrals: orbital coefficients have wrong dimensions");
+    if (ncore + nactive > m_nmo)
+        throw std::runtime_error("FCIDumpInterface::mo_integrals: invalid number of orbitals");
+
+    // Extract active orbital coefficients C_act (m_nbsf x nactive)
+    std::vector<double> Cact(m_nbsf * nactive, 0.0);
+    #pragma omp parallel for collapse(2)
+    for (size_t mu = 0; mu < m_nbsf; mu++)
+    for (size_t p  = 0; p  < nactive; p++)
+        Cact[mu*nactive+p] = C[mu*m_nmo+(p+ncore)];
+
+    // Core density matrix
+    std::vector<double> Pcore(m_nbsf * m_nbsf, 0.0);
+    #pragma omp parallel for collapse(2)
+    for (size_t p = 0; p < m_nbsf; p++)
+    for (size_t q = 0; q < m_nbsf; q++)
+        for (size_t i = 0; i < ncore; i++)
+            Pcore[p*m_nbsf+q] += C[p*m_nmo+i] * C[q*m_nmo+i];
+
+    // Scalar core energy and effective one-electron potential
+    std::vector<double> Veff(nactive * nactive, 0.0);
+    double Vmo = scalar_potential();
+    if (ncore > 0)
+    {
+        std::vector<double> JK(m_nbsf * m_nbsf, 0.0);
+        build_JK(Pcore, JK);
+
+        double *Hao = oei_matrix(true);
+        #pragma omp parallel for reduction(+:Vmo)
+        for (size_t pq = 0; pq < m_nbsf * m_nbsf; pq++)
+            Vmo += 2.0 * (Hao[pq] + 0.5 * JK[pq]) * Pcore[pq];
+
+        oei_transform(Cact, Cact, JK, Veff, nactive, nactive, m_nbsf);
+    }
+
+    // One-electron integrals in active space
+    std::vector<double> h1e_mo(nactive * nactive, 0.0);
+    oei_ao_to_mo(Cact, Cact, h1e_mo, true);
+    if (ncore > 0)
+        for (size_t pq = 0; pq < nactive * nactive; pq++)
+            h1e_mo[pq] += Veff[pq];
+
+    // Two-electron integrals in active space
+    std::vector<double> eri_mo;
+    tei_ao_to_mo(Cact, Cact, Cact, Cact, eri_mo, true, false);
+
+    return MOintegrals(Vmo, h1e_mo, eri_mo, nactive);
+}

--- a/src/fcidump_interface.cpp
+++ b/src/fcidump_interface.cpp
@@ -207,6 +207,10 @@ void FCIDumpInterface::build_JK(
     std::fill(Jt.begin(),Jt.end(),0.0);
     std::fill(Kt.begin(),Kt.end(),0.0);
 
+     
+    // Compute J matrix elements (need to repeat for each density)
+    // Jpq = (pq|rs) * Dsr = \sum_rs <pr|qs> * Dsr
+    // Kps = (pq|rs) * Dqr = \sum_rs <pr|sq> * Dsr
     #pragma omp parallel for collapse(2) schedule(guided)
     for (size_t p=0; p<m_nbsf; p++)
     for (size_t r=0; r<m_nbsf; r++)
@@ -221,40 +225,40 @@ void FCIDumpInterface::build_JK(
             size_t pq = p*m_nbsf+q;
             size_t rs = r*m_nbsf+s;
             if (pq > rs) continue;
-
+            
             double Vpqrs = m_tei[pq*n2+rs];
             if (std::abs(Vpqrs) < thresh) continue;
 
-            J[p*m_nbsf+q] += dens[r*m_nbsf+s] * Vpqrs;
-            K[p*m_nbsf+s] += dens[r*m_nbsf+q] * Vpqrs;
+            J[p*m_nbsf+q] += dens[s*m_nbsf+r] * Vpqrs;
+            K[p*m_nbsf+s] += dens[q*m_nbsf+r] * Vpqrs;
             if (p != q) {
-                J[q*m_nbsf+p] += dens[r*m_nbsf+s] * Vpqrs;
-                K[q*m_nbsf+s] += dens[r*m_nbsf+p] * Vpqrs;
+                J[q*m_nbsf+p] += dens[s*m_nbsf+r] * Vpqrs;
+                K[q*m_nbsf+s] += dens[p*m_nbsf+r] * Vpqrs;
             }
             if (r != s) {
-                J[p*m_nbsf+q] += dens[s*m_nbsf+r] * Vpqrs;
-                K[p*m_nbsf+r] += dens[s*m_nbsf+q] * Vpqrs;
+                J[p*m_nbsf+q] += dens[r*m_nbsf+s] * Vpqrs;
+                K[p*m_nbsf+r] += dens[q*m_nbsf+s] * Vpqrs;
             }
             if (r != s && p != q) {
-                J[q*m_nbsf+p] += dens[s*m_nbsf+r] * Vpqrs;
-                K[q*m_nbsf+r] += dens[s*m_nbsf+p] * Vpqrs;
+                J[q*m_nbsf+p] += dens[r*m_nbsf+s] * Vpqrs;
+                K[q*m_nbsf+r] += dens[p*m_nbsf+s] * Vpqrs;
             }
 
             if (pq != rs)
             {
-                J[r*m_nbsf+s] += dens[p*m_nbsf+q] * Vpqrs;
-                K[r*m_nbsf+q] += dens[p*m_nbsf+s] * Vpqrs;
+                J[r*m_nbsf+s] += dens[q*m_nbsf+p] * Vpqrs;
+                K[r*m_nbsf+q] += dens[s*m_nbsf+p] * Vpqrs;
                 if (r != s) {
-                    J[s*m_nbsf+r] += dens[p*m_nbsf+q] * Vpqrs;
-                    K[s*m_nbsf+q] += dens[p*m_nbsf+r] * Vpqrs;
+                    J[s*m_nbsf+r] += dens[q*m_nbsf+p] * Vpqrs;
+                    K[s*m_nbsf+q] += dens[r*m_nbsf+p] * Vpqrs;
                 }
                 if (p != q) {
-                    J[r*m_nbsf+s] += dens[q*m_nbsf+p] * Vpqrs;
-                    K[r*m_nbsf+p] += dens[q*m_nbsf+s] * Vpqrs;
+                    J[r*m_nbsf+s] += dens[p*m_nbsf+q] * Vpqrs;
+                    K[r*m_nbsf+p] += dens[s*m_nbsf+q] * Vpqrs;
                 }
                 if (r != s && p != q) {
-                    J[s*m_nbsf+r] += dens[q*m_nbsf+p] * Vpqrs;
-                    K[s*m_nbsf+p] += dens[q*m_nbsf+r] * Vpqrs;
+                    J[s*m_nbsf+r] += dens[p*m_nbsf+q] * Vpqrs;
+                    K[s*m_nbsf+p] += dens[r*m_nbsf+q] * Vpqrs;
                 }
             }
         }
@@ -313,40 +317,42 @@ void FCIDumpInterface::build_multiple_JK(
             if(std::abs(Vpqrs) < thresh) continue;
 
             // Compute J matrix elements (need to repeat for each density)
+            // Jpq = (pq|rs) * Dsr = \sum_rs <pr|qs> * Dsr
             for(size_t k=0; k < nj; k++)
             {
                 double *Jt_k = &Jt[k*n2];
                 double *Dj   = &vDJ[k*n2];
-                Jt_k[p*m_nbsf+q] += Dj[r*m_nbsf+s] * Vpqrs;
-                if(p!=q) Jt_k[q*m_nbsf+p] += Dj[r*m_nbsf+s] * Vpqrs;
-                if(r!=s) Jt_k[p*m_nbsf+q] += Dj[s*m_nbsf+r] * Vpqrs;
-                if(r!=s and p!=q) Jt_k[q*m_nbsf+p] += Dj[s*m_nbsf+r] * Vpqrs;
+                Jt_k[p*m_nbsf+q] += Dj[s*m_nbsf+r] * Vpqrs;
+                if(p!=q) Jt_k[q*m_nbsf+p] += Dj[s*m_nbsf+r] * Vpqrs;
+                if(r!=s) Jt_k[p*m_nbsf+q] += Dj[r*m_nbsf+s] * Vpqrs;
+                if(r!=s and p!=q) Jt_k[q*m_nbsf+p] += Dj[r*m_nbsf+s] * Vpqrs;
 
                 if(pq != rs) 
                 {
-                    Jt_k[r*m_nbsf+s] += Dj[p*m_nbsf+q] * Vpqrs;
-                    if(r!=s) Jt_k[s*m_nbsf+r] += Dj[p*m_nbsf+q] * Vpqrs;
-                    if(p!=q) Jt_k[r*m_nbsf+s] += Dj[q*m_nbsf+p] * Vpqrs;
-                    if(r!=s and p!=q) Jt_k[s*m_nbsf+r] += Dj[q*m_nbsf+p] * Vpqrs;
+                    Jt_k[r*m_nbsf+s] += Dj[q*m_nbsf+p] * Vpqrs;
+                    if(r!=s) Jt_k[s*m_nbsf+r] += Dj[q*m_nbsf+p] * Vpqrs;
+                    if(p!=q) Jt_k[r*m_nbsf+s] += Dj[p*m_nbsf+q] * Vpqrs;
+                    if(r!=s and p!=q) Jt_k[s*m_nbsf+r] += Dj[p*m_nbsf+q] * Vpqrs;
                 }                
             }
 
             // Compute K matrix elements (need to repeat for each density)
+            // Kps = (pq|rs) * Dqr = \sum_rs <pr|sq> * Dsr
             for(size_t k=0; k < nk; k++)
             {
                 double *Kt_k = &Kt[k*n2];
                 double *Dk   = &vDK[k*n2];
-                Kt_k[p*m_nbsf+s] += Dk[r*m_nbsf+q] * Vpqrs;
-                if(p!=q) Kt_k[q*m_nbsf+s] += Dk[r*m_nbsf+p] * Vpqrs;
-                if(r!=s) Kt_k[p*m_nbsf+r] += Dk[s*m_nbsf+q] * Vpqrs;
-                if(r!=s and p!=q) Kt_k[q*m_nbsf+r] += Dk[s*m_nbsf+p] * Vpqrs;
+                Kt_k[p*m_nbsf+s] += Dk[q*m_nbsf+r] * Vpqrs;
+                if(p!=q) Kt_k[q*m_nbsf+s] += Dk[p*m_nbsf+r] * Vpqrs;
+                if(r!=s) Kt_k[p*m_nbsf+r] += Dk[q*m_nbsf+s] * Vpqrs;
+                if(r!=s and p!=q) Kt_k[q*m_nbsf+r] += Dk[p*m_nbsf+s] * Vpqrs;
 
                 if(pq != rs) 
                 {
-                    Kt_k[r*m_nbsf+q] += Dk[p*m_nbsf+s] * Vpqrs;
-                    if(r!=s) Kt_k[s*m_nbsf+q] += Dk[p*m_nbsf+r] * Vpqrs;
-                    if(p!=q) Kt_k[r*m_nbsf+p] += Dk[q*m_nbsf+s] * Vpqrs;
-                    if(r!=s and p!=q) Kt_k[s*m_nbsf+p] += Dk[q*m_nbsf+r] * Vpqrs;
+                    Kt_k[r*m_nbsf+q] += Dk[s*m_nbsf+p] * Vpqrs;
+                    if(r!=s) Kt_k[s*m_nbsf+q] += Dk[r*m_nbsf+p] * Vpqrs;
+                    if(p!=q) Kt_k[r*m_nbsf+p] += Dk[s*m_nbsf+q] * Vpqrs;
+                    if(r!=s and p!=q) Kt_k[s*m_nbsf+p] += Dk[r*m_nbsf+q] * Vpqrs;
                 }
             }
         }
@@ -383,102 +389,137 @@ void FCIDumpInterface::tei_ao_to_mo(
 {
     size_t n2 = m_nbsf * m_nbsf;
 
+    // Check dimensions
     assert(C1.size() % m_nbsf == 0);
     assert(C2.size() % m_nbsf == 0);
     assert(C3.size() % m_nbsf == 0);
     assert(C4.size() % m_nbsf == 0);
-
+    
+    // Get number of columns of transformation matrices
     size_t d1 = C1.size() / m_nbsf;
     size_t d2 = C2.size() / m_nbsf;
     size_t d3 = C3.size() / m_nbsf;
     size_t d4 = C4.size() / m_nbsf;
 
-    std::vector<double> tmp1(n2 * n2, 0.0);
-    std::vector<double> tmp2(n2 * n2, 0.0);
+    // Get array dimensions
+    size_t dim = (std::max(m_nbsf,d1) * std::max(m_nbsf,d2) *
+                  std::max(m_nbsf,d3) * std::max(m_nbsf,d4));
 
-    // Antisymmetrise and convert chemist's → physicist's: <mn||st> = (ms|nt) - (mt|ns)
-    double scale = (alpha1 == alpha2) ? 1.0 : 0.0;
+    // Define temporary memory
+    std::vector<double> tmp1(dim, 0.0);
+    std::vector<double> tmp2(dim, 0.0);    
+
+    // Set tmp2 to the antisymmetrised values as appropriate and convert chemist to physicist
+    double scale = (alpha1 == alpha2) ? 1.0 : 0.0; 
     #pragma omp parallel for collapse(4)
-    for (size_t mu = 0; mu < m_nbsf; mu++)
-    for (size_t nu = 0; nu < m_nbsf; nu++)
-    for (size_t sg = 0; sg < m_nbsf; sg++)
-    for (size_t ta = 0; ta < m_nbsf; ta++)
+    for(size_t mu=0; mu < m_nbsf; mu++)
+    for(size_t nu=0; nu < m_nbsf; nu++)
+    for(size_t sg=0; sg < m_nbsf; sg++)
+    for(size_t ta=0; ta < m_nbsf; ta++)
     {
         size_t i1 = (mu*m_nbsf+nu)*n2 + sg*m_nbsf+ta;
         size_t i2 = (mu*m_nbsf+sg)*n2 + nu*m_nbsf+ta;
         size_t i3 = (mu*m_nbsf+ta)*n2 + nu*m_nbsf+sg;
+        // <mn||st> = (ms|nt) - (mt|ns)
         tmp2[i1] = m_tei[i2] - scale * m_tei[i3];
     }
 
+ 
     // Transform s index
     #pragma omp parallel for collapse(2)
-    for (size_t mu = 0; mu < m_nbsf; mu++)
-    for (size_t nu = 0; nu < m_nbsf; nu++)
+    for(size_t mu=0; mu < m_nbsf; mu++)
+    for(size_t nu=0; nu < m_nbsf; nu++)
     {
+        // Define memory buffers
         double *buff1 = &tmp2[mu*m_nbsf*m_nbsf*m_nbsf + nu*m_nbsf*m_nbsf];
-        double *buff2 = &tmp1[mu*m_nbsf*m_nbsf*d4     + nu*m_nbsf*d4];
-        for (size_t sg = 0; sg < m_nbsf; sg++)
-        for (size_t ta = 0; ta < m_nbsf; ta++)
+        double *buff2 = &tmp1[mu*m_nbsf*m_nbsf*d4 + nu*m_nbsf*d4];
+        // Perform inner loop
+        for(size_t sg=0; sg < m_nbsf; sg++)
+        for(size_t ta=0; ta < m_nbsf; ta++)
         {
-            double Iv = buff1[sg*m_nbsf+ta];
-            if (std::abs(Iv) < thresh) continue;
-            for (size_t s = 0; s < d4; s++)
-                buff2[sg*d4+s] += Iv * C4[ta*d4+s];
+            // Get integral value
+            double Ivalue = buff1[sg*m_nbsf + ta];
+            // Skip if integral is (near) zero
+            if(std::abs(Ivalue) < thresh) 
+                continue;
+            // Add contribution to temporary array
+            for(size_t s=0; s < d4; s++)
+                buff2[sg*d4 + s] += Ivalue * C4[ta*d4 + s];
         }
-    }
+    } 
 
     // Transform r index
     std::fill(tmp2.begin(), tmp2.end(), 0.0);
     #pragma omp parallel for collapse(2)
-    for (size_t mu = 0; mu < m_nbsf; mu++)
-    for (size_t nu = 0; nu < m_nbsf; nu++)
+    for(size_t mu=0; mu < m_nbsf; mu++)
+    for(size_t nu=0; nu < m_nbsf; nu++)
     {
+        // Define memory buffers
         double *buff1 = &tmp1[mu*m_nbsf*m_nbsf*d4 + nu*m_nbsf*d4];
-        double *buff2 = &tmp2[mu*m_nbsf*d3*d4     + nu*d3*d4];
-        for (size_t sg = 0; sg < m_nbsf; sg++)
-        for (size_t s  = 0; s  < d4;     s++)
+        double *buff2 = &tmp2[mu*m_nbsf*d3*d4 + nu*d3*d4];
+        // Perform inner loop
+        for(size_t sg=0; sg < m_nbsf; sg++)
+        for(size_t s=0; s < d4; s++)
         {
-            double Iv = buff1[sg*d4+s];
-            if (std::abs(Iv) < thresh) continue;
-            for (size_t r = 0; r < d3; r++)
-                buff2[r*d4+s] += Iv * C3[sg*d3+r];
+            // Get integral value
+            double Ivalue = buff1[sg*d4 + s];
+            // Skip if integral is (near) zero
+            if(std::abs(Ivalue) < thresh) 
+                continue;   
+            // Add contribution to temporary array
+            for(size_t r=0; r < d3; r++)
+                buff2[r*d4 + s] += Ivalue * C3[sg*d3 + r];
         }
     }
 
-    // Transform q index
+    // Transform q index. 
     std::fill(tmp1.begin(), tmp1.end(), 0.0);
     #pragma omp parallel for collapse(2)
-    for (size_t mu = 0; mu < m_nbsf; mu++)
-    for (size_t q  = 0; q  < d2;     q++)
+    for(size_t mu=0; mu < m_nbsf; mu++)
+    for(size_t q=0; q < d2; q++)
     {
+        // Define memory buffers
         double *buff1 = &tmp2[mu*m_nbsf*d3*d4];
-        double *buff2 = &tmp1[mu*d2*d3*d4 + q*d3*d4];
-        for (size_t nu = 0; nu < m_nbsf; nu++)
-        for (size_t r  = 0; r  < d3;     r++)
-        for (size_t s  = 0; s  < d4;     s++)
+        double *buff2 = &tmp1[mu*d2*d3*d4+q*d3*d4];
+
+        // Perform inner loop
+        for(size_t nu=0; nu < m_nbsf; nu++)
+        for(size_t r=0; r < d3; r++)
+        for(size_t s=0; s < d4; s++)
         {
-            double Iv = buff1[nu*d3*d4 + r*d4+s];
-            if (std::abs(Iv) < thresh) continue;
-            buff2[r*d4+s] += Iv * C2[nu*d2+q];
+            // Get integral value
+            double Ivalue = buff1[nu*d3*d4 + r*d4 + s];
+            // Skip if integral is (near) zero
+            if(std::abs(Ivalue) < thresh) 
+                continue;
+            // Add contribution to temporary array
+            buff2[r*d4 + s] += Ivalue * C2[nu*d2 + q];
         }
     }
 
     // Transform p index
-    eri.assign(d1 * d2 * d3 * d4, 0.0);
+    eri.resize(d1*d2*d3*d4);
+    std::fill(eri.begin(), eri.end(), 0.0);
     #pragma omp parallel for collapse(2)
-    for (size_t p = 0; p < d1; p++)
-    for (size_t q = 0; q < d2; q++)
+    for(size_t p=0; p < d1; p++)
+    for(size_t q=0; q < d2; q++)
     {
+        // Define memory buffers
         double *buff1 = &eri[p*d2*d3*d4 + q*d3*d4];
-        for (size_t mu = 0; mu < m_nbsf; mu++)
+        for(size_t mu=0; mu < m_nbsf; mu++)
         {
             double *buff2 = &tmp1[mu*d2*d3*d4];
-            for (size_t r = 0; r < d3; r++)
-            for (size_t s = 0; s < d4; s++)
+            // Perform inner loop
+            for(size_t r=0; r < d3; r++)
+            for(size_t s=0; s < d4; s++)
             {
-                double Iv = buff2[q*d3*d4 + r*d4+s];
-                if (std::abs(Iv) < thresh) continue;
-                buff1[r*d4+s] += Iv * C1[mu*d1+p];
+                // Get integral value
+                double Ivalue = buff2[q*d3*d4 + r*d4 + s];
+                // Skip if integral is (near) zero
+                if(std::abs(Ivalue) < thresh) 
+                    continue;
+                // Add contribution to output array
+                buff1[r*d4 + s] += Ivalue * C1[mu*d1 + p];
             }
         }
     }

--- a/src/fcidump_interface.h
+++ b/src/fcidump_interface.h
@@ -1,0 +1,142 @@
+#ifndef FCIDUMP_INTERFACE_H
+#define FCIDUMP_INTERFACE_H
+
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include "mo_integrals.h"
+#include "linalg.h"
+
+/// \brief FCIDumpInterface class
+/// \details Provides an integral interface backed by a pre-computed FCIDUMP file.
+///          The orbitals in the FCIDUMP are assumed to be orthonormal, so the
+///          overlap and orthogonalisation matrices are both the identity. The
+///          stored AO-labelled arrays (m_oei_a, m_tei, …) actually hold MO
+///          integrals; coefficient matrices passed to the transformation routines
+///          are therefore rotations within the orbital space.
+///          Assume that the FCIDUMP is in restricted orbitals
+class FCIDumpInterface {
+
+protected:
+    size_t m_nbsf;   ///< Number of orbitals (= NORB from header)
+    size_t m_nmo;    ///< Same as m_nbsf (all orbitals are linearly independent)
+    size_t m_nelec;  ///< Total number of electrons (NELEC from header)
+    size_t m_ms2;    ///< 2*Sz (MS2 from header)
+
+    double m_V;                  ///< Scalar potential / nuclear repulsion energy
+    std::vector<double> m_S;     ///< Overlap matrix (identity)
+    std::vector<double> m_X;     ///< Orthogonalisation matrix (identity)
+    std::vector<double> m_oei_a; ///< Alpha one-electron integrals h(p,q)
+    std::vector<double> m_oei_b; ///< Beta  one-electron integrals h(p,q)
+    std::vector<double> m_tei;   ///< Two-electron integrals (pq|rs), chemist's notation
+
+    double thresh = 1e-12; ///< Screening threshold used in JK builds and transformations
+
+public:
+    virtual ~FCIDumpInterface() { }
+
+    /// \brief Construct interface by reading a FCIDUMP file
+    /// \param filename Path to the FCIDUMP file
+    FCIDumpInterface(const std::string &filename) { initialize(filename); }
+
+    /// Number of basis functions (= number of orbitals in the FCIDUMP)
+    size_t nbsf()  const { return m_nbsf;  }
+    /// Number of linearly independent MOs (= nbsf for an orthogonal FCIDUMP)
+    size_t nmo()   const { return m_nmo;   }
+    /// Total number of electrons
+    size_t nelec() const { return m_nelec; }
+    /// Number of alpha electrons
+    size_t nalfa() const { return (m_nelec + m_ms2) / 2; }
+    /// Number of beta electrons
+    size_t nbeta() const { return (m_nelec - m_ms2) / 2; }
+
+    /// Scalar potential (nuclear repulsion + frozen-core offset from FCIDUMP)
+    double scalar_potential() { return m_V; }
+
+    /// Pointer to the overlap matrix (identity for an orthogonal FCIDUMP)
+    double *overlap_matrix()           { return m_S.data();    }
+    /// Pointer to the orthogonalisation matrix (identity for an orthogonal FCIDUMP)
+    double *orthogonalization_matrix() { return m_X.data();    }
+    /// Pointer to the one-electron Hamiltonian matrix (alpha or beta)
+    /// \param alpha True for alpha integrals, false for beta integrals
+    double *oei_matrix(bool alpha)     { return alpha ? m_oei_a.data() : m_oei_b.data(); }
+    /// Pointer to the two-electron integral array (pq|rs) in chemist's notation
+    double *tei_array()                { return m_tei.data();  }
+
+    /// Dipole integrals are not available from a FCIDUMP file
+    double *dipole_integrals()
+    {
+        throw std::runtime_error("FCIDumpInterface: dipole integrals are not available from a FCIDUMP file");
+    }
+
+    /// Build restricted Fock matrix F = h + (2J-K) from a density matrix
+    /// \param dens Density matrix in the same basis as the integrals
+    /// \param fock Output Fock matrix
+    void build_fock(std::vector<double> &dens, std::vector<double> &fock);
+
+    /// Build (2J-K) from a single density matrix
+    /// \param dens Density matrix in the same basis as the integrals
+    /// \param JK Output matrix to hold (2J-K)
+    virtual void build_JK(std::vector<double> &dens, std::vector<double> &JK);
+
+    /// Build J and K matrices for separate sets of density matrices
+    /// \param vDJ Vector of density matrices for J builds (size = nj * nbsf * nbsf)
+    /// \param vDK Vector of density matrices for K builds (size = nk * nbsf * nbsf)
+    /// \param vJ  Output vector of J matrices (size = nj * nbsf * nbsf)
+    /// \param vK  Output vector of K matrices (size = nk * nbsf * nbsf)
+    /// \param nj  Number of densities in vDJ
+    /// \param nk  Number of densities in vDK
+    virtual void build_multiple_JK(
+        std::vector<double> &vDJ, std::vector<double> &vDK,
+        std::vector<double> &vJ,  std::vector<double> &vK,
+        size_t nj, size_t nk);
+
+    /// Transform one-electron integrals from the orbital basis to a new MO basis
+    /// \param C1  Orbital coefficients for the bra state
+    /// \param C2  Orbital coefficients for the ket state
+    /// \param oei_mo Output matrix for one-electron integrals
+    /// \param alpha Spin of oei integrals to use. [true=alpha|false=beta]
+    void oei_ao_to_mo(
+        std::vector<double> &C1, std::vector<double> &C2,
+        std::vector<double> &oei_mo, bool alpha);
+
+    /// Transform two-electron integrals from the orbital basis to a new MO basis.
+    /// Output eri is in physicist's notation <pq||rs> with optional antisymmetrisation.
+    /// \param C1  Orbital coefficients for electron 1 bra state
+    /// \param C2  Orbital coefficients for electron 2 bra state
+    /// \param C3  Orbital coefficients for electron 1 ket state
+    /// \param C4  Orbital coefficients for electron 2 ket state
+    /// \param eri Output array for two-electron integrals in physicist's notation
+    /// \param alpha1 Spin of electron 1 integrals to use. [true=alpha|false=beta]
+    /// \param alpha2 Spin of electron 2 integrals to use. [true=alpha|false=beta]
+    virtual void tei_ao_to_mo(
+        std::vector<double> &C1, std::vector<double> &C2,
+        std::vector<double> &C3, std::vector<double> &C4,
+        std::vector<double> &eri, bool alpha1, bool alpha2);
+
+    /// Build an MOintegrals object for the (ncore, nactive) orbital partition of C
+    /// \param C       Orbital coefficients
+    /// \param ncore   Number of core orbitals
+    /// \param nactive Number of active orbitals
+    MOintegrals mo_integrals(
+        std::vector<double> &C, size_t ncore = 0, size_t nactive = 0);
+
+    /// Parse the FCIDUMP file and initialise all internal arrays
+    /// \param filename Path to the FCIDUMP file
+    void initialize(const std::string &filename);
+
+private:
+    /// Parse the FCIDUMP file
+    void parse_fcidump(const std::string &filename);
+
+    /// Flat index for m_tei in chemist's notation: (pq|rs) = m_tei[tei_index(p,q,r,s)]
+    size_t tei_index(size_t p, size_t q, size_t r, size_t s) const
+    {
+        return p * m_nbsf * m_nbsf * m_nbsf
+             + q * m_nbsf * m_nbsf
+             + r * m_nbsf
+             + s;
+    }
+};
+
+#endif // FCIDUMP_INTERFACE_H

--- a/src/fcidump_interface.h
+++ b/src/fcidump_interface.h
@@ -30,7 +30,7 @@ protected:
     std::vector<double> m_oei_b; ///< Beta  one-electron integrals h(p,q)
     std::vector<double> m_tei;   ///< Two-electron integrals (pq|rs), chemist's notation
 
-    double thresh = 1e-12; ///< Screening threshold used in JK builds and transformations
+    double thresh = -1; ///< Screening threshold used in JK builds and transformations
 
 public:
     virtual ~FCIDumpInterface() { }

--- a/src/libint_interface.cpp
+++ b/src/libint_interface.cpp
@@ -298,6 +298,10 @@ void LibintInterface::build_JK(std::vector<double> &dens, std::vector<double> &J
     std::vector<double> Jt(dev.nthreads*n2), Kt(dev.nthreads*n2);
     std::fill(Jt.begin(),Jt.end(),0.0);
     std::fill(Kt.begin(),Kt.end(),0.0);
+     
+    // Compute J matrix elements (need to repeat for each density)
+    // Jpq = (pq|rs) * Dsr = \sum_rs <pr|qs> * Dsr
+    // Kps = (pq|rs) * Dqr = \sum_rs <pr|sq> * Dsr
 
     // Loop over basis functions
     #pragma omp parallel for collapse(2) schedule(guided)
@@ -319,36 +323,36 @@ void LibintInterface::build_JK(std::vector<double> &dens, std::vector<double> &J
             double Vpqrs = m_tei[pq*n2+rs];
             if(std::abs(Vpqrs) < thresh) continue;
 
-            J[p*m_nbsf+q] += dens[r*m_nbsf+s] * Vpqrs;
-            K[p*m_nbsf+s] += dens[r*m_nbsf+q] * Vpqrs;
+            J[p*m_nbsf+q] += dens[s*m_nbsf+r] * Vpqrs;
+            K[p*m_nbsf+s] += dens[q*m_nbsf+r] * Vpqrs;
             if(p!=q) {
-                J[q*m_nbsf+p] += dens[r*m_nbsf+s] * Vpqrs;
-                K[q*m_nbsf+s] += dens[r*m_nbsf+p] * Vpqrs;
+                J[q*m_nbsf+p] += dens[s*m_nbsf+r] * Vpqrs;
+                K[q*m_nbsf+s] += dens[p*m_nbsf+r] * Vpqrs;
             }
             if(r!=s) {
-                J[p*m_nbsf+q] += dens[s*m_nbsf+r] * Vpqrs;
-                K[p*m_nbsf+r] += dens[s*m_nbsf+q] * Vpqrs;
+                J[p*m_nbsf+q] += dens[r*m_nbsf+s] * Vpqrs;
+                K[p*m_nbsf+r] += dens[q*m_nbsf+s] * Vpqrs;
             }
             if(r!=s and p!=q) {
-                J[q*m_nbsf+p] += dens[s*m_nbsf+r] * Vpqrs;
-                K[q*m_nbsf+r] += dens[s*m_nbsf+p] * Vpqrs;
+                J[q*m_nbsf+p] += dens[r*m_nbsf+s] * Vpqrs;
+                K[q*m_nbsf+r] += dens[p*m_nbsf+s] * Vpqrs;
             }
 
             if(pq != rs) 
             {
-                J[r*m_nbsf+s] += dens[p*m_nbsf+q] * Vpqrs;
-                K[r*m_nbsf+q] += dens[p*m_nbsf+s] * Vpqrs;
+                J[r*m_nbsf+s] += dens[q*m_nbsf+p] * Vpqrs;
+                K[r*m_nbsf+q] += dens[s*m_nbsf+p] * Vpqrs;
                 if(r!=s) {
-                    J[s*m_nbsf+r] += dens[p*m_nbsf+q] * Vpqrs;
-                    K[s*m_nbsf+q] += dens[p*m_nbsf+r] * Vpqrs;
+                    J[s*m_nbsf+r] += dens[q*m_nbsf+p] * Vpqrs;
+                    K[s*m_nbsf+q] += dens[r*m_nbsf+p] * Vpqrs;
                 }
                 if(p!=q) {
-                    J[r*m_nbsf+s] += dens[q*m_nbsf+p] * Vpqrs;
-                    K[r*m_nbsf+p] += dens[q*m_nbsf+s] * Vpqrs;
+                    J[r*m_nbsf+s] += dens[p*m_nbsf+q] * Vpqrs;
+                    K[r*m_nbsf+p] += dens[s*m_nbsf+q] * Vpqrs;
                 }
                 if(r!=s and p!=q) {
-                    J[s*m_nbsf+r] += dens[q*m_nbsf+p] * Vpqrs;
-                    K[s*m_nbsf+p] += dens[q*m_nbsf+r] * Vpqrs;
+                    J[s*m_nbsf+r] += dens[p*m_nbsf+q] * Vpqrs;
+                    K[s*m_nbsf+p] += dens[r*m_nbsf+q] * Vpqrs;
                 }
             }
         }
@@ -411,17 +415,17 @@ void LibintInterface::build_multiple_JK(
             {
                 double *Jt_k = &Jt[k*n2];
                 double *Dj   = &vDJ[k*n2];
-                Jt_k[p*m_nbsf+q] += Dj[r*m_nbsf+s] * Vpqrs;
-                if(p!=q) Jt_k[q*m_nbsf+p] += Dj[r*m_nbsf+s] * Vpqrs;
-                if(r!=s) Jt_k[p*m_nbsf+q] += Dj[s*m_nbsf+r] * Vpqrs;
-                if(r!=s and p!=q) Jt_k[q*m_nbsf+p] += Dj[s*m_nbsf+r] * Vpqrs;
+                Jt_k[p*m_nbsf+q] += Dj[s*m_nbsf+r] * Vpqrs;
+                if(p!=q) Jt_k[q*m_nbsf+p] += Dj[s*m_nbsf+r] * Vpqrs;
+                if(r!=s) Jt_k[p*m_nbsf+q] += Dj[r*m_nbsf+s] * Vpqrs;
+                if(r!=s and p!=q) Jt_k[q*m_nbsf+p] += Dj[r*m_nbsf+s] * Vpqrs;
 
                 if(pq != rs) 
                 {
-                    Jt_k[r*m_nbsf+s] += Dj[p*m_nbsf+q] * Vpqrs;
-                    if(r!=s) Jt_k[s*m_nbsf+r] += Dj[p*m_nbsf+q] * Vpqrs;
-                    if(p!=q) Jt_k[r*m_nbsf+s] += Dj[q*m_nbsf+p] * Vpqrs;
-                    if(r!=s and p!=q) Jt_k[s*m_nbsf+r] += Dj[q*m_nbsf+p] * Vpqrs;
+                    Jt_k[r*m_nbsf+s] += Dj[q*m_nbsf+p] * Vpqrs;
+                    if(r!=s) Jt_k[s*m_nbsf+r] += Dj[q*m_nbsf+p] * Vpqrs;
+                    if(p!=q) Jt_k[r*m_nbsf+s] += Dj[p*m_nbsf+q] * Vpqrs;
+                    if(r!=s and p!=q) Jt_k[s*m_nbsf+r] += Dj[p*m_nbsf+q] * Vpqrs;
                 }                
             }
 
@@ -430,17 +434,17 @@ void LibintInterface::build_multiple_JK(
             {
                 double *Kt_k = &Kt[k*n2];
                 double *Dk   = &vDK[k*n2];
-                Kt_k[p*m_nbsf+s] += Dk[r*m_nbsf+q] * Vpqrs;
-                if(p!=q) Kt_k[q*m_nbsf+s] += Dk[r*m_nbsf+p] * Vpqrs;
-                if(r!=s) Kt_k[p*m_nbsf+r] += Dk[s*m_nbsf+q] * Vpqrs;
-                if(r!=s and p!=q) Kt_k[q*m_nbsf+r] += Dk[s*m_nbsf+p] * Vpqrs;
+                Kt_k[p*m_nbsf+s] += Dk[q*m_nbsf+r] * Vpqrs;
+                if(p!=q) Kt_k[q*m_nbsf+s] += Dk[p*m_nbsf+r] * Vpqrs;
+                if(r!=s) Kt_k[p*m_nbsf+r] += Dk[q*m_nbsf+s] * Vpqrs;
+                if(r!=s and p!=q) Kt_k[q*m_nbsf+r] += Dk[p*m_nbsf+s] * Vpqrs;
 
                 if(pq != rs) 
                 {
-                    Kt_k[r*m_nbsf+q] += Dk[p*m_nbsf+s] * Vpqrs;
-                    if(r!=s) Kt_k[s*m_nbsf+q] += Dk[p*m_nbsf+r] * Vpqrs;
-                    if(p!=q) Kt_k[r*m_nbsf+p] += Dk[q*m_nbsf+s] * Vpqrs;
-                    if(r!=s and p!=q) Kt_k[s*m_nbsf+p] += Dk[q*m_nbsf+r] * Vpqrs;
+                    Kt_k[r*m_nbsf+q] += Dk[s*m_nbsf+p] * Vpqrs;
+                    if(r!=s) Kt_k[s*m_nbsf+q] += Dk[r*m_nbsf+p] * Vpqrs;
+                    if(p!=q) Kt_k[r*m_nbsf+p] += Dk[s*m_nbsf+q] * Vpqrs;
+                    if(r!=s and p!=q) Kt_k[s*m_nbsf+p] += Dk[r*m_nbsf+q] * Vpqrs;
                 }
             }
         }
@@ -476,9 +480,12 @@ void LibintInterface::tei_ao_to_mo(
     size_t d3 = C3.size() / m_nbsf;
     size_t d4 = C4.size() / m_nbsf;
 
+    size_t dim = (std::max(d1,m_nbsf) * std::max(d2,m_nbsf) 
+                * std::max(d3,m_nbsf) * std::max(d4,m_nbsf));
+
     // Define temporary memory
-    std::vector<double> tmp1(n2*n2, 0.0);
-    std::vector<double> tmp2(n2*n2, 0.0);    
+    std::vector<double> tmp1(dim, 0.0);
+    std::vector<double> tmp2(dim, 0.0);    
 
     // Set tmp2 to the antisymmetrised values as appropriate and convert chemist to physicist
     double scale = (alpha1 == alpha2) ? 1.0 : 0.0; 

--- a/src/libint_interface.cpp
+++ b/src/libint_interface.cpp
@@ -188,7 +188,7 @@ void LibintInterface::compute_two_electron_integrals()
         for(size_t f3=0; f3 < n3; ++f3)
         for(size_t f4=0; f4 < n4; ++f4)
         {
-            // Save value for aabb block in physicists notation
+            // Save value for aabb block in chemists notation
             double value = ints[f1*strides[0] + f2*strides[1] + f3*strides[2] + f4];
             m_tei[tei_index(bf1+f1,bf2+f2,bf3+f3,bf4+f4)] = value;
         }


### PR DESCRIPTION
Created a new C++ interface to read integrals from a FCIDUMP file. This is implemented in [https://github.com/hgaburton/quantel/blob/intdump_interface/src/fcidump_interface.cpp](url). A new set of pybind11 bindings is provided and a python wrapper is given in [https://github.com/hgaburton/quantel/blob/intdump_interface/quantel/ints/fcidump_integrals.py](url). 

A script to benchmark the integral library against PySCFIntegrals.py is provided in [https://github.com/hgaburton/quantel/blob/intdump_interface/examples/test_fcidump.py] (url). 

A script to check that RHF, UHF, and GHF all run correctly with the fcidump interface is provided in [https://github.com/hgaburton/quantel/blob/intdump_interface/examples/fcidump_scf.py] (url). 